### PR TITLE
fix: Keep controls fixed at top

### DIFF
--- a/resources/plot.html.tera
+++ b/resources/plot.html.tera
@@ -152,6 +152,11 @@
             border-style: solid;
             border-color: #333 transparent transparent transparent;
         }
+
+        #vis {
+            overflow: auto;
+            height: calc(100vh - 220px);
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `resources/plot.html.tera` file. It adds a new CSS rule to ensure the `#vis` element has a scrollable area with a height dynamically calculated to fit the viewport. This way the controls stay accessible at all times.