### PR TITLE
feat: Add new wizard mode for interactive plot generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,7 @@ dependencies = [
  "anyhow",
  "bio",
  "csv",
+ "inquire",
  "itertools 0.14.0",
  "log",
  "rand 0.9.1",
@@ -443,6 +444,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +577,12 @@ dependencies = [
  "quote",
  "syn 2.0.101",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "editdistancek"
@@ -703,6 +735,15 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -1167,6 +1208,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
+dependencies = [
+ "bitflags 2.9.0",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "fxhash",
+ "newline-converter",
+ "once_cell",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,6 +1414,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
@@ -1421,6 +1491,15 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
+]
+
+[[package]]
+name = "newline-converter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -2228,6 +2307,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio 0.8.11",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2531,6 +2631,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2582,7 +2692,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
+ "mio 1.0.3",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -3060,6 +3170,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3074,6 +3193,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3110,6 +3244,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3122,6 +3262,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3131,6 +3277,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3158,6 +3310,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3167,6 +3325,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3182,6 +3346,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3191,6 +3361,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ csv = "1.3.1"
 tera = "1.20.0"
 reqwest = "0.12" # 0.12 seems to cause issues fetching vega libs from cdn
 tokio = { version = "1", features = ["full"] }
+inquire = "0.7.5"
 
 [profile.release]
 lto = "fat"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 A tool for creating alignment plots from bam files. The generated [vega-lite](https://vega.github.io/vega-lite/) plots are written to stdout per default.
 An example of a generated plot can be seen [here](http://htmlpreview.github.io/?https://github.com/koesterlab/alignoth/blob/main/examples/plot.html)
 The name alignoth is derived from the visualized **align**ments combined with the star **alioth** (usage of vega plots).
-To run ```alignoth``` in interactive mode, simply execute it without any arguments.
+
+Alignoth supports an interactive mode that can be activated by simply executing it without any arguments (i.e. `alignoth`).
 This launches a wizard that guides you through selecting input files, defining the region of interest, and choosing between an interactive HTML output or a Vega-Lite specification.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -10,7 +10,14 @@
 A tool for creating alignment plots from bam files. The generated [vega-lite](https://vega.github.io/vega-lite/) plots are written to stdout per default.
 An example of a generated plot can be seen [here](http://htmlpreview.github.io/?https://github.com/koesterlab/alignoth/blob/main/examples/plot.html)
 The name alignoth is derived from the visualized **align**ments combined with the star **alioth** (usage of vega plots).
+To run ```alignoth``` in interactive mode, simply execute it without any arguments.
+This launches a wizard that guides you through selecting input files, defining the region of interest, and choosing between an interactive HTML output or a Vega-Lite specification.
+
 ## Usage
+
+```alignoth```
+
+To activate the interactive mode guiding you through the process of creating an alignment plot.
 
 ```alignoth -b path/to/my.bam -r path/to/my/reference.fa -g chr1:200-300 > plot.vl.json```
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -44,6 +44,17 @@ pub(crate) fn get_fasta_length(fasta_path: &PathBuf, target: &str) -> Result<usi
     Ok(seq.len())
 }
 
+// Get all contigs/chromosomes from fasta file
+pub(crate) fn get_fasta_contigs(fasta_path: &PathBuf) -> Result<Vec<String>> {
+    let fasta_reader = fasta::Reader::from_file(fasta_path)?;
+    let mut contigs = Vec::new();
+    for record in fasta_reader.records() {
+        let record = record?;
+        contigs.push(record.id().to_string());
+    }
+    Ok(contigs)
+}
+
 /// Takes any given aux and returns a string representation of it.
 pub(crate) fn aux_to_string(aux: rust_htslib::bam::record::Aux) -> String {
     match aux {
@@ -70,7 +81,7 @@ pub(crate) fn aux_to_string(aux: rust_htslib::bam::record::Aux) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::utils::{get_fasta_length, get_ref_and_bam_from_cwd};
+    use crate::utils::{get_fasta_contigs, get_fasta_length, get_ref_and_bam_from_cwd};
     use std::path::PathBuf;
     use std::str::FromStr;
 
@@ -88,5 +99,12 @@ mod tests {
     fn test_get_ref_and_bam_from_empty_cwd() {
         let result = get_ref_and_bam_from_cwd().unwrap();
         assert_eq!(result, None)
+    }
+
+    #[test]
+    fn test_get_fasta_contigs() {
+        let contigs =
+            get_fasta_contigs(&PathBuf::from_str("tests/sample_1/reference.fa").unwrap()).unwrap();
+        assert_eq!(contigs, vec!["chr1".to_string()])
     }
 }

--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -1,0 +1,93 @@
+use crate::cli::{Alignoth, Interval, Region};
+use crate::utils::get_fasta_contigs;
+use anyhow::Result;
+use inquire::{Confirm, Select, Text};
+use std::fs;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+pub(crate) async fn wizard_mode() -> Result<Alignoth> {
+    println!("Welcome to Alignoth wizard mode 🪄 Let's build your plot interactively.\n");
+
+    let current_dir = std::env::current_dir()?;
+    let bam_files: Vec<_> = fs::read_dir(&current_dir)?
+        .filter_map(|entry| entry.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|ext| ext == "bam"))
+        .collect();
+    let fasta_files: Vec<_> = fs::read_dir(&current_dir)?
+        .filter_map(|entry| entry.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.extension()
+                .is_some_and(|ext| ext == "fa" || ext == "fasta")
+        })
+        .collect();
+
+    let bam_path = if bam_files.is_empty() {
+        Text::new("Path to BAM file:").prompt()?
+    } else {
+        let choices: Vec<_> = bam_files.iter().map(|p| p.display().to_string()).collect();
+        Select::new("Select BAM file:", choices).prompt()?
+    };
+
+    let reference_path = if fasta_files.is_empty() {
+        Text::new("Path to reference FASTA file:").prompt()?
+    } else {
+        let choices: Vec<_> = fasta_files
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect();
+        Select::new("Select reference FASTA file:", choices).prompt()?
+    };
+
+    let contigs = get_fasta_contigs(&PathBuf::from(reference_path.clone()))?;
+    let target = Select::new("Select target contig/chromosome:", contigs).prompt()?;
+    let start = Text::new("Start coordinate:").prompt()?.parse()?;
+    let end = Text::new("End coordinate:").prompt()?.parse()?;
+    let region = Region { target, start, end };
+    let highlight_input = Text::new("Do you want to highlight a specific region or position? (Example: 1000-2000 or 1200, press Enter to skip)").prompt()?;
+    let highlight = if highlight_input.is_empty() {
+        None
+    } else {
+        Some(Interval::from_str(&highlight_input)?)
+    };
+    let aux_tag_input =
+        Text::new("Optional auxiliary tags (whitespace-separated, press Enter to skip):")
+            .prompt_skippable()?;
+    let aux_tags = aux_tag_input.and_then(|s| {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.split_whitespace().map(String::from).collect())
+        }
+    });
+
+    let max_depth = Text::new("Max read depth (default 500):")
+        .with_default("500")
+        .prompt()?;
+
+    let html_output = Confirm::new("Generate interactive HTML instead of Vega-Lite specs?")
+        .with_default(true)
+        .prompt()?;
+
+    Ok(Alignoth {
+        bam_path: Some(bam_path.into()),
+        reference: Some(reference_path.into()),
+        region: Some(region),
+        aux_tag: aux_tags,
+        max_read_depth: max_depth.parse()?,
+        max_width: 1024,
+        output: None,
+        data_format: Default::default(),
+        html: html_output,
+        around: None,
+        plot_all: false,
+        highlight,
+        highlight_data_output: None,
+        spec_output: None,
+        ref_data_output: None,
+        read_data_output: None,
+    })
+}


### PR DESCRIPTION
This pull request introduces a new "wizard mode" to the application, enabling users to interactively generate plots through a guided CLI interface. It also includes utility enhancements and modifications to the main application logic to support this feature. Below are the most significant changes:

### Wizard Mode Implementation:
* Added a new module `wizard` with the `wizard_mode` function, which provides an interactive CLI for users to select BAM/FASTA files, specify regions, and configure plot settings. It utilizes the `inquire` library for prompts.
* Integrated `wizard_mode` into the `main` function in `src/main.rs`, allowing the application to detect when no arguments are passed and switch to wizard mode.

### Dependency Updates:
* Added the `inquire` crate (version 0.7.5) to `Cargo.toml` to enable interactive CLI prompts.

### Enhancements to Plot Output:
* Updated the `main` function to save plot outputs (HTML or Vega-Lite JSON) with filenames derived from the input BAM file when using wizard mode. This ensures clear output file naming. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR143-R152) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR180-R191)

### Utility Functions:
* Introduced a new utility function `get_fasta_contigs` in `src/utils.rs` to extract contig/chromosome names from a FASTA file, which is used in wizard mode for user selection.
* Added a unit test for `get_fasta_contigs` to validate its functionality.

### Codebase Modifications:
* Updated imports in `src/main.rs` and `src/utils.rs` to include the new `wizard` module and utility function. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR4-R8) [[2]](diffhunk://#diff-23af5356f6001cd3993cd3c801fb7716ea02d1e504081b9fb569332db6107e80L73-R84)