### PR TITLE
feat: Add coverage plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The following options are available when using alignoth:
 | read-data-output      |       | If present read data will be written to the given file path                                                                                                       |         |
 | ref-data-output       |       | If present reference data will be written to the given file path                                                                                                  |         |
 | highlight-data-output |       | If present highlight data will be written to the given file path                                                                                                  |         |
+| coverage-data-output  |       | If present coverage data will be written to the given file path                                                                                                  |         |
 | html                  |       | If present the generated plot will inserted into a plain html file containing the plot centered which is then written to stdout                                   |         |
 
 ## Installation

--- a/resources/plot.vl.json
+++ b/resources/plot.vl.json
@@ -1,8 +1,5 @@
 {
     "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
-    "height": {
-        "step": 4
-    },
     "resolve": {
         "scale": {
             "strokeWidth": "independent"
@@ -11,7 +8,8 @@
     "datasets": {
         "highlight": [],
         "reference": [],
-        "reads": []
+        "reads": [],
+        "coverage": []
     },
     "config": {
         "legend": {
@@ -25,977 +23,1039 @@
             }
         }
     },
-    "encoding": {
-        "x": {
-            "field": "start",
-            "type": "quantitative",
-            "axis": {
-                "orient": "top",
-                "title": "position (1-based)"
-            },
-            "scale": {
-                "domain": []
-            }
-        },
-        "x2": {
-            "field": "end",
-            "type": "quantitative"
-        },
-        "y": {
-            "axis": null,
-            "field": "row",
-            "type": "ordinal"
-        },
-        "yOffset": {
-          "field": "v_offset",
-          "type": "ordinal"
-        }
-    },
-    "layer": [
+    "vconcat": [
         {
             "data": {
-                "name": "highlight"
+                "name": "coverage"
             },
-            "mark": "rect",
-            "encoding": {
-                "color": {
-                    "value": "red"
-                },
-                "opacity": {
-                    "value": 0.15
-                },
-                "y2": {
-                    "value": 10000000
-                }
-            }
-        },
-        {
-            "data": {
-                "name": "reference"
-            },
-            "params": [
-                {
-                    "name": "grid",
-                    "select": "interval",
-                    "bind": "scales"
-                }
-            ],
+            "mark": "area",
             "transform": [
-                {
-                    "as": "base",
-                    "calculate": "split(datum.reference, '')"
-                },
                 {
                     "as": "offset",
-                    "calculate": "sequence(datum.reference.length)"
+                    "calculate": "sequence(datum.coverage.length)"
                 },
                 {
                     "flatten": [
-                        "base",
-                        "offset"
+                        "offset",
+                        "coverage"
                     ]
                 },
                 {
-                    "as": "position",
+                    "as": "p",
                     "calculate": "datum.start + datum.offset"
-                },
-                {
-                    "as": "start",
-                    "calculate": "datum.position + 0.5"
-                },
-                {
-                    "as": "end",
-                    "calculate": "datum.position + 1.5"
-                },
-                {
-                    "as": "position (1-based)",
-                    "calculate": "datum.position + 1"
-                }
-            ],
-            "mark": {
-                "type": "rule",
-                "clip": true
-            },
-            "encoding": {
-                "tooltip": [
-                    {
-                        "field": "base"
-                    },
-                    {
-                        "field": "position (1-based)"
-                    }
-                ],
-                "strokeWidth": {
-                    "value": 8
-                },
-                "color": {
-                    "field": "base",
-                    "legend": null,
-                    "scale": {
-                        "type": "ordinal",
-                        "domain": [
-                            "A",
-                            "C",
-                            "G",
-                            "T",
-                            "N",
-                            "match",
-                            "deletion",
-                            "insertion"
-                        ],
-                        "range": [
-                            "#CADB69",
-                            "#F2B671",
-                            "#F28CC2",
-                            "#7284A8",
-                            "#A23E11",
-                            "#BBBBBB",
-                            "#CC1414",
-                            "#047C0A"
-                        ]
-                    }
-                }
-            }
-        },
-        {
-            "data": {
-                "name": "reads"
-            },
-            "transform": [
-                {
-                  "calculate": "split(datum.values, '§')",
-                  "as": "reads"
-                },
-                {
-                  "flatten": ["reads"]
-                },
-                {
-                  "calculate": "split(datum.reads, ' ')",
-                  "as": "fields"
-                },
-                {
-                  "calculate": "replace(datum.fields[0], '_', ' ')",
-                  "as": "aux"
-                },
-                {
-                  "calculate": "datum.fields[1]",
-                  "as": "cigar"
-                },
-                {
-                  "calculate": "toNumber(datum.fields[2])",
-                  "as": "flags"
-                },
-                {
-                  "calculate": "toNumber(datum.fields[3])",
-                  "as": "mapq"
-                },
-                {
-                  "calculate": "toNumber(datum.fields[4])",
-                  "as": "mpos"
-                },
-                {
-                  "calculate": "datum.fields[5]",
-                  "as": "name"
-                },
-                {
-                  "calculate": "toNumber(datum.fields[6])",
-                  "as": "position"
-                },
-                {
-                  "calculate": "datum.fields[7] === '.' ? null : toNumber(datum.fields[7])",
-                  "as": "row"
-                },
-                {
-                  "calculate": "datum.fields[8]",
-                  "as": "raw_cigar"
-                },
-                {
-                    "as": "cigars",
-                    "calculate": "split(datum.cigar, '|')"
-                },
-                {
-                    "as": "cigar_index",
-                    "calculate": "sequence(datum.cigars.length)"
-                },
-                {
-                    "flatten": [
-                        "cigars",
-                        "cigar_index"
-                    ]
-                },
-                {
-                    "calculate": "if(substring(datum.cigars, 0, 1) == 'i', 'insertion', if(substring(datum.cigars, length(datum.cigars) - 1, length(datum.cigars)) == '=', 'match', if(substring(datum.cigars, length(datum.cigars) - 1, length(datum.cigars)) == 'd', 'deletion', substring(datum.cigars, 1, length(datum.cigars)))))",
-                    "as": "type"
-                },
-                {
-                    "calculate": "if(datum.type == 'match' || datum.type == 'deletion', parseInt(substring(datum.cigars, 0, length(datum.cigars) - 1)), if(datum.type == 'insertion', 1, parseInt(substring(datum.cigars, 0, length(datum.cigars) - 1))))",
-                    "as": "length"
-                },
-                {
-                    "stack": "length",
-                    "groupby": [
-                        "name",
-                        "cigar",
-                        "position"
-                    ],
-                    "as": "offset"
-                },
-                {
-                    "as": "start",
-                    "calculate": "if(datum.type == 'insertion', datum.position + datum.offset + 1.4, datum.position + datum.offset + 0.4)"
-                },
-                {
-                    "as": "end",
-                    "calculate": "if(datum.type == 'insertion', datum.position + datum.offset + datum.length - 0.4, datum.position + datum.offset + datum.length + 0.6)"
-                },
-                {
-                  "as": "v_offset",
-                  "calculate": "if(datum.position < datum.mpos, 0, 2)"
-                }
-            ],
-            "mark": {
-                "type": "rule",
-                "clip": true
-            },
-            "params": [
-                {
-                    "name": "rplc",
-                    "select": {
-                        "type": "point",
-                        "toggle": "event.shiftKey",
-                        "fields": ["name", "position"]
-                    }
                 }
             ],
             "encoding": {
-                "opacity": {
-                    "condition": {
-                        "param": "rplc",
-                        "value": 1
-                    },
-                    "value": 0.2
-                },
-                "strokeWidth": {
-                    "field": "type",
-                    "scale": {
-                        "type": "ordinal",
-                        "domain": [
-                            "A",
-                            "C",
-                            "G",
-                            "T",
-                            "N",
-                            "match",
-                            "deletion",
-                            "insertion"
-                        ],
-                        "range": [
-                            9,
-                            9,
-                            9,
-                            9,
-                            9,
-                            9,
-                            9,
-                            12
-                        ]
-                    },
-                    "legend": null
-                },
-                "color": {
-                    "field": "mapq",
+                "x": {
+                    "field": "p",
                     "type": "quantitative",
+                    "axis": {
+                        "title": null
+                    },
                     "scale": {
-                        "domain": [
-                            0,
-                            60
-                        ],
-                        "range": [
-                            "#910000",
-                            "#c70002",
-                            "#ff0000",
-                            "#ff7500",
-                            "#ffb200",
-                            "#ffe921",
-                            "#bbbbbb"
-                        ]
+                        "domain": []
+                    }
+                },
+                "y": {
+                    "field": "coverage",
+                    "type": "quantitative",
+                    "axis": {
+                        "title": "coverage"
                     }
                 }
-            }
+            },
+            "height": 60
         },
         {
-            "data": {
-                "name": "reads"
-            },
-            "transform": [
-                {
-                  "calculate": "split(datum.values, '§')",
-                  "as": "reads"
-                },
-                {
-                  "flatten": ["reads"]
-                },
-                {
-                  "calculate": "split(datum.reads, ' ')",
-                  "as": "fields"
-                },
-                {
-                  "calculate": "replace(datum.fields[0], '_', ' ')",
-                  "as": "aux"
-                },
-                {
-                  "calculate": "datum.fields[1]",
-                  "as": "cigar"
-                },
-                {
-                  "calculate": "toNumber(datum.fields[2])",
-                  "as": "flags"
-                },
-                {
-                  "calculate": "toNumber(datum.fields[3])",
-                  "as": "mapq"
-                },
-                {
-                  "calculate": "toNumber(datum.fields[4])",
-                  "as": "mpos"
-                },
-                {
-                  "calculate": "datum.fields[5]",
-                  "as": "name"
-                },
-                {
-                  "calculate": "toNumber(datum.fields[6])",
-                  "as": "position"
-                },
-                {
-                  "calculate": "datum.fields[7] === '.' ? null : toNumber(datum.fields[7])",
-                  "as": "row"
-                },
-                {
-                  "calculate": "datum.fields[8]",
-                  "as": "raw_cigar"
-                },
-                {
-                    "filter": "datum.mpos >= 0"
-                },
-                {
-                    "as": "start",
-                    "calculate": "if(datum.position < datum.mpos, datum.position + 0.5, datum.mpos + 0.5)"
-                },
-                {
-                    "as": "end",
-                    "calculate": "if(datum.position > datum.mpos, datum.position + 0.5, datum.mpos + 0.5)"
-                },
-                {
-                  "as": "v_offset",
-                  "calculate": "1"
-                }
-            ],
-            "mark": {
-                "type": "rule",
-                "clip": true
+            "height": {
+                "step": 4
             },
             "encoding": {
-                "opacity": {
-                    "condition": {
-                        "param": "rplc",
-                        "value": 1
+                "x": {
+                    "field": "start",
+                    "type": "quantitative",
+                    "axis": {
+                        "orient": "top",
+                        "title": "position (1-based)"
                     },
-                    "value": 0.2
+                    "scale": {
+                        "domain": []
+                    }
                 },
-                "strokeWidth": {
-                    "value": 1
+                "x2": {
+                    "field": "end",
+                    "type": "quantitative"
                 },
-                "color": {
-                    "value": "#BBBBBB"
+                "y": {
+                    "axis": null,
+                    "field": "row",
+                    "type": "ordinal"
+                },
+                "yOffset": {
+                    "field": "v_offset",
+                    "type": "ordinal"
                 }
-            }
-        },
-        {
-            "data": {
-                "name": "reads"
             },
-            "transform": [
+            "layer": [
                 {
-                  "calculate": "split(datum.values, '§')",
-                  "as": "reads"
+                    "data": {
+                        "name": "highlight"
+                    },
+                    "mark": "rect",
+                    "encoding": {
+                        "color": {
+                            "value": "red"
+                        },
+                        "opacity": {
+                            "value": 0.15
+                        },
+                        "y2": {
+                            "value": 10000000
+                        }
+                    }
                 },
                 {
-                  "flatten": ["reads"]
-                },
-                {
-                  "calculate": "split(datum.reads, ' ')",
-                  "as": "fields"
-                },
-                {
-                  "calculate": "replace(datum.fields[0], '_', ' ')",
-                  "as": "aux"
-                },
-                {
-                  "calculate": "datum.fields[1]",
-                  "as": "cigar"
-                },
-                {
-                  "calculate": "toNumber(datum.fields[2])",
-                  "as": "flags"
-                },
-                {
-                  "calculate": "toNumber(datum.fields[3])",
-                  "as": "mapq"
-                },
-                {
-                  "calculate": "toNumber(datum.fields[4])",
-                  "as": "mpos"
-                },
-                {
-                  "calculate": "datum.fields[5]",
-                  "as": "name"
-                },
-                {
-                  "calculate": "toNumber(datum.fields[6])",
-                  "as": "position"
-                },
-                {
-                  "calculate": "datum.fields[7] === '.' ? null : toNumber(datum.fields[7])",
-                  "as": "row"
-                },
-                {
-                  "calculate": "datum.fields[8]",
-                  "as": "raw_cigar"
-                },
-                {
-                    "calculate": "join([if ((datum.flags & 1) > 0, 'read paired, ', ''), if ((datum.flags & 2) > 0, 'read mapped in proper pair, ', ''),  if ((datum.flags & 4) > 0, 'read unmapped, ', ''), if ((datum.flags & 8) > 0, 'mate unmapped, ', ''), if ((datum.flags & 16) > 0, 'read reverse strand, ', ''), if ((datum.flags & 32) > 0, 'mate reverse strand, ', ''), if ((datum.flags & 64) > 0, 'first in pair, ', ''), if ((datum.flags & 128) > 0, 'second in pair, ', ''), if ((datum.flags & 256) > 0, 'not primary alignment, ', ''), if ((datum.flags & 512) > 0, 'read fails platform/vendor quality checks, ', ''), if ((datum.flags & 1024) > 0, 'read is PCR or optical duplicate, ', ''), if ((datum.flags & 2048) > 0, 'supplementary alignment, ', '')], '')",
-                    "as": "flags"
-                },
-                {
-                    "as": "cigars",
-                    "calculate": "split(datum.cigar, '|')"
-                },
-                {
-                    "as": "cigar_index",
-                    "calculate": "sequence(datum.cigars.length)"
-                },
-                {
-                    "flatten": [
-                        "cigars",
-                        "cigar_index"
-                    ]
-                },
-                {
-                    "calculate": "if(substring(datum.cigars, 0, 1) == 'i', 'insertion', if(substring(datum.cigars, length(datum.cigars) - 1, length(datum.cigars)) == '=', 'match', if(substring(datum.cigars, length(datum.cigars) - 1, length(datum.cigars)) == 'd', 'deletion', substring(datum.cigars, 1, length(datum.cigars)))))",
-                    "as": "type"
-                },
-                {
-                    "calculate": "if(datum.type == 'match' || datum.type == 'deletion', parseInt(substring(datum.cigars, 0, length(datum.cigars) - 1)), if(datum.type == 'insertion', 1, parseInt(substring(datum.cigars, 0, length(datum.cigars) - 1))))",
-                    "as": "length"
-                },
-                {
-                    "stack": "length",
-                    "groupby": [
-                        "name",
-                        "cigar",
-                        "position"
+                    "data": {
+                        "name": "reference"
+                    },
+                    "params": [
+                        {
+                            "name": "grid",
+                            "select": "interval",
+                            "bind": "scales"
+                        }
                     ],
-                    "as": "offset"
-                },
-                {
-                    "as": "start",
-                    "calculate": "datum.position + datum.offset + 0.5"
-                },
-                {
-                    "as": "end",
-                    "calculate": "datum.position + datum.offset + datum.length + 0.5"
-                },
-                {
-                    "filter": "datum.type != 'deletion' && datum.type != 'insertion'"
-                },
-                {
-                  "as": "v_offset",
-                  "calculate": "if(datum.position < datum.mpos, 0, 2)"
-                }
-            ],
-            "mark": {
-                "type": "rule",
-                "clip": true
-            },
-            "encoding": {
-                "tooltip": [
-                    {
-                        "field": "name"
-                    },
-                    {
-                        "field": "type"
-                    },
-                    {
-                        "field": "mapq"
-                    },
-                    {
-                        "field": "flags"
-                    },
-                    {
-                        "field": "aux"
-                    },
-                    {
-                      "field": "raw_cigar"
-                    }
-                ],
-                "opacity": {
-                    "condition": {
-                        "param": "rplc",
-                        "value": 1
-                    },
-                    "value": 0.2
-                },
-                "strokeWidth": {
-                    "field": "type",
-                    "scale": {
-                        "type": "ordinal",
-                        "domain": [
-                            "A",
-                            "C",
-                            "G",
-                            "T",
-                            "N",
-                            "match",
-                            "deletion",
-                            "insertion"
-                        ],
-                        "range": [
-                            6,
-                            6,
-                            6,
-                            6,
-                            6,
-                            6,
-                            6,
-                            9
-                        ]
-                    },
-                    "legend": null
-                },
-                "color": {
-                    "field": "type",
-                    "legend": null,
-                    "scale": {
-                        "type": "ordinal",
-                        "domain": [
-                            "A",
-                            "C",
-                            "G",
-                            "T",
-                            "N",
-                            "match",
-                            "deletion",
-                            "insertion"
-                        ],
-                        "range": [
-                            "#CADB69",
-                            "#F2B671",
-                            "#F28CC2",
-                            "#7284A8",
-                            "#A23E11",
-                            "#BBBBBB",
-                            "#CC1414",
-                            "#047C0A"
-                        ]
-                    }
-                }
-            }
-        },
-        {
-            "data": {
-                "name": "reads"
-            },
-            "transform": [
-                {
-                  "calculate": "split(datum.values, '§')",
-                  "as": "reads"
-                },
-                {
-                  "flatten": ["reads"]
-                },
-                {
-                  "calculate": "split(datum.reads, ' ')",
-                  "as": "fields"
-                },
-                {
-                  "calculate": "replace(datum.fields[0], '_', ' ')",
-                  "as": "aux"
-                },
-                {
-                  "calculate": "datum.fields[1]",
-                  "as": "cigar"
-                },
-                {
-                  "calculate": "toNumber(datum.fields[2])",
-                  "as": "flags"
-                },
-                {
-                  "calculate": "toNumber(datum.fields[3])",
-                  "as": "mapq"
-                },
-                {
-                  "calculate": "toNumber(datum.fields[4])",
-                  "as": "mpos"
-                },
-                {
-                  "calculate": "datum.fields[5]",
-                  "as": "name"
-                },
-                {
-                  "calculate": "toNumber(datum.fields[6])",
-                  "as": "position"
-                },
-                {
-                  "calculate": "datum.fields[7] === '.' ? null : toNumber(datum.fields[7])",
-                  "as": "row"
-                },
-                {
-                  "calculate": "datum.fields[8]",
-                  "as": "raw_cigar"
-                },
-                {
-                    "calculate": "join([if ((datum.flags & 1) > 0, 'read paired, ', ''), if ((datum.flags & 2) > 0, 'read mapped in proper pair, ', ''),  if ((datum.flags & 4) > 0, 'read unmapped, ', ''), if ((datum.flags & 8) > 0, 'mate unmapped, ', ''), if ((datum.flags & 16) > 0, 'read reverse strand, ', ''), if ((datum.flags & 32) > 0, 'mate reverse strand, ', ''), if ((datum.flags & 64) > 0, 'first in pair, ', ''), if ((datum.flags & 128) > 0, 'second in pair, ', ''), if ((datum.flags & 256) > 0, 'not primary alignment, ', ''), if ((datum.flags & 512) > 0, 'read fails platform/vendor quality checks, ', ''), if ((datum.flags & 1024) > 0, 'read is PCR or optical duplicate, ', ''), if ((datum.flags & 2048) > 0, 'supplementary alignment, ', '')], '')",
-                    "as": "flags"
-                },
-                {
-                    "as": "cigars",
-                    "calculate": "split(datum.cigar, '|')"
-                },
-                {
-                    "as": "cigar_index",
-                    "calculate": "sequence(datum.cigars.length)"
-                },
-                {
-                    "flatten": [
-                        "cigars",
-                        "cigar_index"
-                    ]
-                },
-                {
-                    "calculate": "if(substring(datum.cigars, 0, 1) == 'i', 'insertion', if(substring(datum.cigars, length(datum.cigars) - 1, length(datum.cigars)) == '=', 'match', if(substring(datum.cigars, length(datum.cigars) - 1, length(datum.cigars)) == 'd', 'deletion', substring(datum.cigars, 1, length(datum.cigars)))))",
-                    "as": "type"
-                },
-                {
-                    "calculate": "if(datum.type == 'match' || datum.type == 'deletion', parseInt(substring(datum.cigars, 0, length(datum.cigars) - 1)), if(datum.type == 'insertion', 1, parseInt(substring(datum.cigars, 0, length(datum.cigars) - 1))))",
-                    "as": "length"
-                },
-                {
-                    "stack": "length",
-                    "groupby": [
-                        "name",
-                        "cigar",
-                        "position"
+                    "transform": [
+                        {
+                            "as": "base",
+                            "calculate": "split(datum.reference, '')"
+                        },
+                        {
+                            "as": "offset",
+                            "calculate": "sequence(datum.reference.length)"
+                        },
+                        {
+                            "flatten": [
+                                "base",
+                                "offset"
+                            ]
+                        },
+                        {
+                            "as": "position",
+                            "calculate": "datum.start + datum.offset"
+                        },
+                        {
+                            "as": "start",
+                            "calculate": "datum.position + 0.5"
+                        },
+                        {
+                            "as": "end",
+                            "calculate": "datum.position + 1.5"
+                        },
+                        {
+                            "as": "position (1-based)",
+                            "calculate": "datum.position + 1"
+                        }
                     ],
-                    "as": "offset"
-                },
-                {
-                    "as": "start",
-                    "calculate": "datum.position + datum.offset + 0.5"
-                },
-                {
-                    "as": "end",
-                    "calculate": "datum.position + datum.offset + datum.length + 0.5"
-                },
-                {
-                    "as": "inserted bases",
-                    "calculate": "substring(datum.cigars, 1, length(datum.cigars))"
-                },
-                {
-                    "filter": "datum.type == 'insertion'"
-                },
-                {
-                  "as": "v_offset",
-                  "calculate": "if(datum.position < datum.mpos, 0, 2)"
-                }
-            ],
-            "mark": {
-                "type": "rule",
-                "clip": true
-            },
-            "encoding": {
-                "tooltip": [
-                    {
-                        "field": "name"
+                    "mark": {
+                        "type": "rule",
+                        "clip": true
                     },
-                    {
-                        "field": "type"
-                    },
-                    {
-                        "field": "mapq"
-                    },
-                    {
-                        "field": "flags"
-                    },
-                    {
-                        "field": "aux"
-                    },
-                    {
-                        "field": "inserted bases"
-                    },
-                    {
-                      "field": "raw_cigar"
-                    }
-                ],
-                "opacity": {
-                    "condition": {
-                        "param": "rplc",
-                        "value": 1
-                    },
-                    "value": 0.2
-                },
-                "strokeWidth": {
-                    "field": "type",
-                    "scale": {
-                        "type": "ordinal",
-                        "domain": [
-                            "A",
-                            "C",
-                            "G",
-                            "T",
-                            "N",
-                            "match",
-                            "deletion",
-                            "insertion"
+                    "encoding": {
+                        "tooltip": [
+                            {
+                                "field": "base"
+                            },
+                            {
+                                "field": "position (1-based)"
+                            }
                         ],
-                        "range": [
-                            6,
-                            6,
-                            6,
-                            6,
-                            6,
-                            6,
-                            6,
-                            9
-                        ]
-                    },
-                    "legend": null
-                },
-                "color": {
-                    "field": "type",
-                    "legend": null,
-                    "scale": {
-                        "type": "ordinal",
-                        "domain": [
-                            "A",
-                            "C",
-                            "G",
-                            "T",
-                            "N",
-                            "match",
-                            "deletion",
-                            "insertion"
-                        ],
-                        "range": [
-                            "#CADB69",
-                            "#F2B671",
-                            "#F28CC2",
-                            "#7284A8",
-                            "#A23E11",
-                            "#BBBBBB",
-                            "#CC1414",
-                            "#047C0A"
-                        ]
+                        "strokeWidth": {
+                            "value": 8
+                        },
+                        "color": {
+                            "field": "base",
+                            "legend": null,
+                            "scale": {
+                                "type": "ordinal",
+                                "domain": [
+                                    "A",
+                                    "C",
+                                    "G",
+                                    "T",
+                                    "N",
+                                    "match",
+                                    "deletion",
+                                    "insertion"
+                                ],
+                                "range": [
+                                    "#CADB69",
+                                    "#F2B671",
+                                    "#F28CC2",
+                                    "#7284A8",
+                                    "#A23E11",
+                                    "#BBBBBB",
+                                    "#CC1414",
+                                    "#047C0A"
+                                ]
+                            }
+                        }
                     }
-                }
-            }
-        },
-        {
-            "data": {
-                "name": "reads"
-            },
-            "transform": [
-                {
-                  "calculate": "split(datum.values, '§')",
-                  "as": "reads"
                 },
                 {
-                  "flatten": ["reads"]
-                },
-                {
-                  "calculate": "split(datum.reads, ' ')",
-                  "as": "fields"
-                },
-                {
-                  "calculate": "replace(datum.fields[0], '_', ' ')",
-                  "as": "aux"
-                },
-                {
-                  "calculate": "datum.fields[1]",
-                  "as": "cigar"
-                },
-                {
-                  "calculate": "toNumber(datum.fields[2])",
-                  "as": "flags"
-                },
-                {
-                  "calculate": "toNumber(datum.fields[3])",
-                  "as": "mapq"
-                },
-                {
-                  "calculate": "toNumber(datum.fields[4])",
-                  "as": "mpos"
-                },
-                {
-                  "calculate": "datum.fields[5]",
-                  "as": "name"
-                },
-                {
-                  "calculate": "toNumber(datum.fields[6])",
-                  "as": "position"
-                },
-                {
-                  "calculate": "datum.fields[7] === '.' ? null : toNumber(datum.fields[7])",
-                  "as": "row"
-                },
-                {
-                  "calculate": "datum.fields[8]",
-                  "as": "raw_cigar"
-                },
-                {
-                    "calculate": "join([if ((datum.flags & 1) > 0, 'read paired, ', ''), if ((datum.flags & 2) > 0, 'read mapped in proper pair, ', ''),  if ((datum.flags & 4) > 0, 'read unmapped, ', ''), if ((datum.flags & 8) > 0, 'mate unmapped, ', ''), if ((datum.flags & 16) > 0, 'read reverse strand, ', ''), if ((datum.flags & 32) > 0, 'mate reverse strand, ', ''), if ((datum.flags & 64) > 0, 'first in pair, ', ''), if ((datum.flags & 128) > 0, 'second in pair, ', ''), if ((datum.flags & 256) > 0, 'not primary alignment, ', ''), if ((datum.flags & 512) > 0, 'read fails platform/vendor quality checks, ', ''), if ((datum.flags & 1024) > 0, 'read is PCR or optical duplicate, ', ''), if ((datum.flags & 2048) > 0, 'supplementary alignment, ', '')], '')",
-                    "as": "flags"
-                },
-                {
-                    "as": "cigars",
-                    "calculate": "split(datum.cigar, '|')"
-                },
-                {
-                    "as": "cigar_index",
-                    "calculate": "sequence(datum.cigars.length)"
-                },
-                {
-                    "flatten": [
-                        "cigars",
-                        "cigar_index"
-                    ]
-                },
-                {
-                    "calculate": "if(substring(datum.cigars, 0, 1) == 'i', 'insertion', if(substring(datum.cigars, length(datum.cigars) - 1, length(datum.cigars)) == '=', 'match', if(substring(datum.cigars, length(datum.cigars) - 1, length(datum.cigars)) == 'd', 'deletion', substring(datum.cigars, 1, length(datum.cigars)))))",
-                    "as": "type"
-                },
-                {
-                    "calculate": "if(datum.type == 'match' || datum.type == 'deletion', parseInt(substring(datum.cigars, 0, length(datum.cigars) - 1)), if(datum.type == 'insertion', 1, parseInt(substring(datum.cigars, 0, length(datum.cigars) - 1))))",
-                    "as": "length"
-                },
-                {
-                    "stack": "length",
-                    "groupby": [
-                        "name",
-                        "cigar",
-                        "position"
+                    "data": {
+                        "name": "reads"
+                    },
+                    "transform": [
+                        {
+                            "calculate": "split(datum.values, '\u00a7')",
+                            "as": "reads"
+                        },
+                        {
+                            "flatten": [
+                                "reads"
+                            ]
+                        },
+                        {
+                            "calculate": "split(datum.reads, ' ')",
+                            "as": "fields"
+                        },
+                        {
+                            "calculate": "replace(datum.fields[0], '_', ' ')",
+                            "as": "aux"
+                        },
+                        {
+                            "calculate": "datum.fields[1]",
+                            "as": "cigar"
+                        },
+                        {
+                            "calculate": "toNumber(datum.fields[2])",
+                            "as": "flags"
+                        },
+                        {
+                            "calculate": "toNumber(datum.fields[3])",
+                            "as": "mapq"
+                        },
+                        {
+                            "calculate": "toNumber(datum.fields[4])",
+                            "as": "mpos"
+                        },
+                        {
+                            "calculate": "datum.fields[5]",
+                            "as": "name"
+                        },
+                        {
+                            "calculate": "toNumber(datum.fields[6])",
+                            "as": "position"
+                        },
+                        {
+                            "calculate": "datum.fields[7] === '.' ? null : toNumber(datum.fields[7])",
+                            "as": "row"
+                        },
+                        {
+                            "calculate": "datum.fields[8]",
+                            "as": "raw_cigar"
+                        },
+                        {
+                            "as": "cigars",
+                            "calculate": "split(datum.cigar, '|')"
+                        },
+                        {
+                            "as": "cigar_index",
+                            "calculate": "sequence(datum.cigars.length)"
+                        },
+                        {
+                            "flatten": [
+                                "cigars",
+                                "cigar_index"
+                            ]
+                        },
+                        {
+                            "calculate": "if(substring(datum.cigars, 0, 1) == 'i', 'insertion', if(substring(datum.cigars, length(datum.cigars) - 1, length(datum.cigars)) == '=', 'match', if(substring(datum.cigars, length(datum.cigars) - 1, length(datum.cigars)) == 'd', 'deletion', substring(datum.cigars, 1, length(datum.cigars)))))",
+                            "as": "type"
+                        },
+                        {
+                            "calculate": "if(datum.type == 'match' || datum.type == 'deletion', parseInt(substring(datum.cigars, 0, length(datum.cigars) - 1)), if(datum.type == 'insertion', 1, parseInt(substring(datum.cigars, 0, length(datum.cigars) - 1))))",
+                            "as": "length"
+                        },
+                        {
+                            "stack": "length",
+                            "groupby": [
+                                "name",
+                                "cigar",
+                                "position"
+                            ],
+                            "as": "offset"
+                        },
+                        {
+                            "as": "start",
+                            "calculate": "if(datum.type == 'insertion', datum.position + datum.offset + 1.4, datum.position + datum.offset + 0.4)"
+                        },
+                        {
+                            "as": "end",
+                            "calculate": "if(datum.type == 'insertion', datum.position + datum.offset + datum.length - 0.4, datum.position + datum.offset + datum.length + 0.6)"
+                        },
+                        {
+                            "as": "v_offset",
+                            "calculate": "if(datum.position < datum.mpos, 0, 2)"
+                        }
                     ],
-                    "as": "offset"
-                },
-                {
-                    "as": "start",
-                    "calculate": "if(datum.type == 'insertion', datum.position + datum.offset + 1, datum.position + datum.offset + 0.5)"
-                },
-                {
-                    "as": "end",
-                    "calculate": "if(datum.type == 'insertion', datum.position + datum.offset + datum.length, datum.position + datum.offset + datum.length + 0.5)"
-                },
-                {
-                    "filter": "datum.type == 'deletion'"
-                },
-                {
-                  "as": "v_offset",
-                  "calculate": "if(datum.position < datum.mpos, 0, 2)"
-                }
-            ],
-            "mark": {
-                "type": "rule",
-                "clip": true
-            },
-            "encoding": {
-                "tooltip": [
-                    {
-                        "field": "name"
+                    "mark": {
+                        "type": "rule",
+                        "clip": true
                     },
-                    {
-                        "field": "type"
-                    },
-                    {
-                        "field": "mapq"
-                    },
-                    {
-                        "field": "flags"
-                    },
-                    {
-                        "field": "length"
-                    },
-                    {
-                        "field": "aux"
-                    },
-                    {
-                      "field": "raw_cigar"
+                    "params": [
+                        {
+                            "name": "rplc",
+                            "select": {
+                                "type": "point",
+                                "toggle": "event.shiftKey",
+                                "fields": [
+                                    "name",
+                                    "position"
+                                ]
+                            }
+                        }
+                    ],
+                    "encoding": {
+                        "opacity": {
+                            "condition": {
+                                "param": "rplc",
+                                "value": 1
+                            },
+                            "value": 0.2
+                        },
+                        "strokeWidth": {
+                            "field": "type",
+                            "scale": {
+                                "type": "ordinal",
+                                "domain": [
+                                    "A",
+                                    "C",
+                                    "G",
+                                    "T",
+                                    "N",
+                                    "match",
+                                    "deletion",
+                                    "insertion"
+                                ],
+                                "range": [
+                                    9,
+                                    9,
+                                    9,
+                                    9,
+                                    9,
+                                    9,
+                                    9,
+                                    12
+                                ]
+                            },
+                            "legend": null
+                        },
+                        "color": {
+                            "field": "mapq",
+                            "type": "quantitative",
+                            "scale": {
+                                "domain": [
+                                    0,
+                                    60
+                                ],
+                                "range": [
+                                    "#910000",
+                                    "#c70002",
+                                    "#ff0000",
+                                    "#ff7500",
+                                    "#ffb200",
+                                    "#ffe921",
+                                    "#bbbbbb"
+                                ]
+                            }
+                        }
                     }
-                ],
-                "opacity": {
-                    "condition": {
-                        "param": "rplc",
-                        "value": 1
-                    },
-                    "value": 0.2
                 },
-                "strokeWidth": {
-                    "field": "type",
-                    "scale": {
-                        "type": "ordinal",
-                        "domain": [
-                            "A",
-                            "C",
-                            "G",
-                            "T",
-                            "N",
-                            "match",
-                            "deletion",
-                            "insertion"
-                        ],
-                        "range": [
-                            6,
-                            6,
-                            6,
-                            6,
-                            6,
-                            6,
-                            6,
-                            9
-                        ]
+                {
+                    "data": {
+                        "name": "reads"
                     },
-                    "legend": null
+                    "transform": [
+                        {
+                            "calculate": "split(datum.values, '\u00a7')",
+                            "as": "reads"
+                        },
+                        {
+                            "flatten": [
+                                "reads"
+                            ]
+                        },
+                        {
+                            "calculate": "split(datum.reads, ' ')",
+                            "as": "fields"
+                        },
+                        {
+                            "calculate": "replace(datum.fields[0], '_', ' ')",
+                            "as": "aux"
+                        },
+                        {
+                            "calculate": "datum.fields[1]",
+                            "as": "cigar"
+                        },
+                        {
+                            "calculate": "toNumber(datum.fields[2])",
+                            "as": "flags"
+                        },
+                        {
+                            "calculate": "toNumber(datum.fields[3])",
+                            "as": "mapq"
+                        },
+                        {
+                            "calculate": "toNumber(datum.fields[4])",
+                            "as": "mpos"
+                        },
+                        {
+                            "calculate": "datum.fields[5]",
+                            "as": "name"
+                        },
+                        {
+                            "calculate": "toNumber(datum.fields[6])",
+                            "as": "position"
+                        },
+                        {
+                            "calculate": "datum.fields[7] === '.' ? null : toNumber(datum.fields[7])",
+                            "as": "row"
+                        },
+                        {
+                            "calculate": "datum.fields[8]",
+                            "as": "raw_cigar"
+                        },
+                        {
+                            "filter": "datum.mpos >= 0"
+                        },
+                        {
+                            "as": "start",
+                            "calculate": "if(datum.position < datum.mpos, datum.position + 0.5, datum.mpos + 0.5)"
+                        },
+                        {
+                            "as": "end",
+                            "calculate": "if(datum.position > datum.mpos, datum.position + 0.5, datum.mpos + 0.5)"
+                        },
+                        {
+                            "as": "v_offset",
+                            "calculate": "1"
+                        }
+                    ],
+                    "mark": {
+                        "type": "rule",
+                        "clip": true
+                    },
+                    "encoding": {
+                        "opacity": {
+                            "condition": {
+                                "param": "rplc",
+                                "value": 1
+                            },
+                            "value": 0.2
+                        },
+                        "strokeWidth": {
+                            "value": 1
+                        },
+                        "color": {
+                            "value": "#BBBBBB"
+                        }
+                    }
                 },
-                "color": {
-                    "field": "type",
-                    "legend": {
-                        "symbolSize": 75,
-                        "title": "symbol"
+                {
+                    "data": {
+                        "name": "reads"
                     },
-                    "scale": {
-                        "type": "ordinal",
-                        "domain": [
-                            "A",
-                            "C",
-                            "G",
-                            "T",
-                            "N",
-                            "match",
-                            "deletion",
-                            "insertion"
+                    "transform": [
+                        {
+                            "calculate": "split(datum.values, '\u00a7')",
+                            "as": "reads"
+                        },
+                        {
+                            "flatten": [
+                                "reads"
+                            ]
+                        },
+                        {
+                            "calculate": "split(datum.reads, ' ')",
+                            "as": "fields"
+                        },
+                        {
+                            "calculate": "replace(datum.fields[0], '_', ' ')",
+                            "as": "aux"
+                        },
+                        {
+                            "calculate": "datum.fields[1]",
+                            "as": "cigar"
+                        },
+                        {
+                            "calculate": "toNumber(datum.fields[2])",
+                            "as": "flags"
+                        },
+                        {
+                            "calculate": "toNumber(datum.fields[3])",
+                            "as": "mapq"
+                        },
+                        {
+                            "calculate": "toNumber(datum.fields[4])",
+                            "as": "mpos"
+                        },
+                        {
+                            "calculate": "datum.fields[5]",
+                            "as": "name"
+                        },
+                        {
+                            "calculate": "toNumber(datum.fields[6])",
+                            "as": "position"
+                        },
+                        {
+                            "calculate": "datum.fields[7] === '.' ? null : toNumber(datum.fields[7])",
+                            "as": "row"
+                        },
+                        {
+                            "calculate": "datum.fields[8]",
+                            "as": "raw_cigar"
+                        },
+                        {
+                            "calculate": "join([if ((datum.flags & 1) > 0, 'read paired, ', ''), if ((datum.flags & 2) > 0, 'read mapped in proper pair, ', ''),  if ((datum.flags & 4) > 0, 'read unmapped, ', ''), if ((datum.flags & 8) > 0, 'mate unmapped, ', ''), if ((datum.flags & 16) > 0, 'read reverse strand, ', ''), if ((datum.flags & 32) > 0, 'mate reverse strand, ', ''), if ((datum.flags & 64) > 0, 'first in pair, ', ''), if ((datum.flags & 128) > 0, 'second in pair, ', ''), if ((datum.flags & 256) > 0, 'not primary alignment, ', ''), if ((datum.flags & 512) > 0, 'read fails platform/vendor quality checks, ', ''), if ((datum.flags & 1024) > 0, 'read is PCR or optical duplicate, ', ''), if ((datum.flags & 2048) > 0, 'supplementary alignment, ', '')], '')",
+                            "as": "flags"
+                        },
+                        {
+                            "as": "cigars",
+                            "calculate": "split(datum.cigar, '|')"
+                        },
+                        {
+                            "as": "cigar_index",
+                            "calculate": "sequence(datum.cigars.length)"
+                        },
+                        {
+                            "flatten": [
+                                "cigars",
+                                "cigar_index"
+                            ]
+                        },
+                        {
+                            "calculate": "if(substring(datum.cigars, 0, 1) == 'i', 'insertion', if(substring(datum.cigars, length(datum.cigars) - 1, length(datum.cigars)) == '=', 'match', if(substring(datum.cigars, length(datum.cigars) - 1, length(datum.cigars)) == 'd', 'deletion', substring(datum.cigars, 1, length(datum.cigars)))))",
+                            "as": "type"
+                        },
+                        {
+                            "calculate": "if(datum.type == 'match' || datum.type == 'deletion', parseInt(substring(datum.cigars, 0, length(datum.cigars) - 1)), if(datum.type == 'insertion', 1, parseInt(substring(datum.cigars, 0, length(datum.cigars) - 1))))",
+                            "as": "length"
+                        },
+                        {
+                            "stack": "length",
+                            "groupby": [
+                                "name",
+                                "cigar",
+                                "position"
+                            ],
+                            "as": "offset"
+                        },
+                        {
+                            "as": "start",
+                            "calculate": "datum.position + datum.offset + 0.5"
+                        },
+                        {
+                            "as": "end",
+                            "calculate": "datum.position + datum.offset + datum.length + 0.5"
+                        },
+                        {
+                            "filter": "datum.type != 'deletion' && datum.type != 'insertion'"
+                        },
+                        {
+                            "as": "v_offset",
+                            "calculate": "if(datum.position < datum.mpos, 0, 2)"
+                        }
+                    ],
+                    "mark": {
+                        "type": "rule",
+                        "clip": true
+                    },
+                    "encoding": {
+                        "tooltip": [
+                            {
+                                "field": "name"
+                            },
+                            {
+                                "field": "type"
+                            },
+                            {
+                                "field": "mapq"
+                            },
+                            {
+                                "field": "flags"
+                            },
+                            {
+                                "field": "aux"
+                            },
+                            {
+                                "field": "raw_cigar"
+                            }
                         ],
-                        "range": [
-                            "#CADB69",
-                            "#F2B671",
-                            "#F28CC2",
-                            "#7284A8",
-                            "#A23E11",
-                            "#BBBBBB",
-                            "#CC1414",
-                            "#047C0A"
-                        ]
+                        "opacity": {
+                            "condition": {
+                                "param": "rplc",
+                                "value": 1
+                            },
+                            "value": 0.2
+                        },
+                        "strokeWidth": {
+                            "field": "type",
+                            "scale": {
+                                "type": "ordinal",
+                                "domain": [
+                                    "A",
+                                    "C",
+                                    "G",
+                                    "T",
+                                    "N",
+                                    "match",
+                                    "deletion",
+                                    "insertion"
+                                ],
+                                "range": [
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    9
+                                ]
+                            },
+                            "legend": null
+                        },
+                        "color": {
+                            "field": "type",
+                            "legend": null,
+                            "scale": {
+                                "type": "ordinal",
+                                "domain": [
+                                    "A",
+                                    "C",
+                                    "G",
+                                    "T",
+                                    "N",
+                                    "match",
+                                    "deletion",
+                                    "insertion"
+                                ],
+                                "range": [
+                                    "#CADB69",
+                                    "#F2B671",
+                                    "#F28CC2",
+                                    "#7284A8",
+                                    "#A23E11",
+                                    "#BBBBBB",
+                                    "#CC1414",
+                                    "#047C0A"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "data": {
+                        "name": "reads"
+                    },
+                    "transform": [
+                        {
+                            "calculate": "split(datum.values, '\u00a7')",
+                            "as": "reads"
+                        },
+                        {
+                            "flatten": [
+                                "reads"
+                            ]
+                        },
+                        {
+                            "calculate": "split(datum.reads, ' ')",
+                            "as": "fields"
+                        },
+                        {
+                            "calculate": "replace(datum.fields[0], '_', ' ')",
+                            "as": "aux"
+                        },
+                        {
+                            "calculate": "datum.fields[1]",
+                            "as": "cigar"
+                        },
+                        {
+                            "calculate": "toNumber(datum.fields[2])",
+                            "as": "flags"
+                        },
+                        {
+                            "calculate": "toNumber(datum.fields[3])",
+                            "as": "mapq"
+                        },
+                        {
+                            "calculate": "toNumber(datum.fields[4])",
+                            "as": "mpos"
+                        },
+                        {
+                            "calculate": "datum.fields[5]",
+                            "as": "name"
+                        },
+                        {
+                            "calculate": "toNumber(datum.fields[6])",
+                            "as": "position"
+                        },
+                        {
+                            "calculate": "datum.fields[7] === '.' ? null : toNumber(datum.fields[7])",
+                            "as": "row"
+                        },
+                        {
+                            "calculate": "datum.fields[8]",
+                            "as": "raw_cigar"
+                        },
+                        {
+                            "calculate": "join([if ((datum.flags & 1) > 0, 'read paired, ', ''), if ((datum.flags & 2) > 0, 'read mapped in proper pair, ', ''),  if ((datum.flags & 4) > 0, 'read unmapped, ', ''), if ((datum.flags & 8) > 0, 'mate unmapped, ', ''), if ((datum.flags & 16) > 0, 'read reverse strand, ', ''), if ((datum.flags & 32) > 0, 'mate reverse strand, ', ''), if ((datum.flags & 64) > 0, 'first in pair, ', ''), if ((datum.flags & 128) > 0, 'second in pair, ', ''), if ((datum.flags & 256) > 0, 'not primary alignment, ', ''), if ((datum.flags & 512) > 0, 'read fails platform/vendor quality checks, ', ''), if ((datum.flags & 1024) > 0, 'read is PCR or optical duplicate, ', ''), if ((datum.flags & 2048) > 0, 'supplementary alignment, ', '')], '')",
+                            "as": "flags"
+                        },
+                        {
+                            "as": "cigars",
+                            "calculate": "split(datum.cigar, '|')"
+                        },
+                        {
+                            "as": "cigar_index",
+                            "calculate": "sequence(datum.cigars.length)"
+                        },
+                        {
+                            "flatten": [
+                                "cigars",
+                                "cigar_index"
+                            ]
+                        },
+                        {
+                            "calculate": "if(substring(datum.cigars, 0, 1) == 'i', 'insertion', if(substring(datum.cigars, length(datum.cigars) - 1, length(datum.cigars)) == '=', 'match', if(substring(datum.cigars, length(datum.cigars) - 1, length(datum.cigars)) == 'd', 'deletion', substring(datum.cigars, 1, length(datum.cigars)))))",
+                            "as": "type"
+                        },
+                        {
+                            "calculate": "if(datum.type == 'match' || datum.type == 'deletion', parseInt(substring(datum.cigars, 0, length(datum.cigars) - 1)), if(datum.type == 'insertion', 1, parseInt(substring(datum.cigars, 0, length(datum.cigars) - 1))))",
+                            "as": "length"
+                        },
+                        {
+                            "stack": "length",
+                            "groupby": [
+                                "name",
+                                "cigar",
+                                "position"
+                            ],
+                            "as": "offset"
+                        },
+                        {
+                            "as": "start",
+                            "calculate": "datum.position + datum.offset + 0.5"
+                        },
+                        {
+                            "as": "end",
+                            "calculate": "datum.position + datum.offset + datum.length + 0.5"
+                        },
+                        {
+                            "as": "inserted bases",
+                            "calculate": "substring(datum.cigars, 1, length(datum.cigars))"
+                        },
+                        {
+                            "filter": "datum.type == 'insertion'"
+                        },
+                        {
+                            "as": "v_offset",
+                            "calculate": "if(datum.position < datum.mpos, 0, 2)"
+                        }
+                    ],
+                    "mark": {
+                        "type": "rule",
+                        "clip": true
+                    },
+                    "encoding": {
+                        "tooltip": [
+                            {
+                                "field": "name"
+                            },
+                            {
+                                "field": "type"
+                            },
+                            {
+                                "field": "mapq"
+                            },
+                            {
+                                "field": "flags"
+                            },
+                            {
+                                "field": "aux"
+                            },
+                            {
+                                "field": "inserted bases"
+                            },
+                            {
+                                "field": "raw_cigar"
+                            }
+                        ],
+                        "opacity": {
+                            "condition": {
+                                "param": "rplc",
+                                "value": 1
+                            },
+                            "value": 0.2
+                        },
+                        "strokeWidth": {
+                            "field": "type",
+                            "scale": {
+                                "type": "ordinal",
+                                "domain": [
+                                    "A",
+                                    "C",
+                                    "G",
+                                    "T",
+                                    "N",
+                                    "match",
+                                    "deletion",
+                                    "insertion"
+                                ],
+                                "range": [
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    9
+                                ]
+                            },
+                            "legend": null
+                        },
+                        "color": {
+                            "field": "type",
+                            "legend": null,
+                            "scale": {
+                                "type": "ordinal",
+                                "domain": [
+                                    "A",
+                                    "C",
+                                    "G",
+                                    "T",
+                                    "N",
+                                    "match",
+                                    "deletion",
+                                    "insertion"
+                                ],
+                                "range": [
+                                    "#CADB69",
+                                    "#F2B671",
+                                    "#F28CC2",
+                                    "#7284A8",
+                                    "#A23E11",
+                                    "#BBBBBB",
+                                    "#CC1414",
+                                    "#047C0A"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "data": {
+                        "name": "reads"
+                    },
+                    "transform": [
+                        {
+                            "calculate": "split(datum.values, '\u00a7')",
+                            "as": "reads"
+                        },
+                        {
+                            "flatten": [
+                                "reads"
+                            ]
+                        },
+                        {
+                            "calculate": "split(datum.reads, ' ')",
+                            "as": "fields"
+                        },
+                        {
+                            "calculate": "replace(datum.fields[0], '_', ' ')",
+                            "as": "aux"
+                        },
+                        {
+                            "calculate": "datum.fields[1]",
+                            "as": "cigar"
+                        },
+                        {
+                            "calculate": "toNumber(datum.fields[2])",
+                            "as": "flags"
+                        },
+                        {
+                            "calculate": "toNumber(datum.fields[3])",
+                            "as": "mapq"
+                        },
+                        {
+                            "calculate": "toNumber(datum.fields[4])",
+                            "as": "mpos"
+                        },
+                        {
+                            "calculate": "datum.fields[5]",
+                            "as": "name"
+                        },
+                        {
+                            "calculate": "toNumber(datum.fields[6])",
+                            "as": "position"
+                        },
+                        {
+                            "calculate": "datum.fields[7] === '.' ? null : toNumber(datum.fields[7])",
+                            "as": "row"
+                        },
+                        {
+                            "calculate": "datum.fields[8]",
+                            "as": "raw_cigar"
+                        },
+                        {
+                            "calculate": "join([if ((datum.flags & 1) > 0, 'read paired, ', ''), if ((datum.flags & 2) > 0, 'read mapped in proper pair, ', ''),  if ((datum.flags & 4) > 0, 'read unmapped, ', ''), if ((datum.flags & 8) > 0, 'mate unmapped, ', ''), if ((datum.flags & 16) > 0, 'read reverse strand, ', ''), if ((datum.flags & 32) > 0, 'mate reverse strand, ', ''), if ((datum.flags & 64) > 0, 'first in pair, ', ''), if ((datum.flags & 128) > 0, 'second in pair, ', ''), if ((datum.flags & 256) > 0, 'not primary alignment, ', ''), if ((datum.flags & 512) > 0, 'read fails platform/vendor quality checks, ', ''), if ((datum.flags & 1024) > 0, 'read is PCR or optical duplicate, ', ''), if ((datum.flags & 2048) > 0, 'supplementary alignment, ', '')], '')",
+                            "as": "flags"
+                        },
+                        {
+                            "as": "cigars",
+                            "calculate": "split(datum.cigar, '|')"
+                        },
+                        {
+                            "as": "cigar_index",
+                            "calculate": "sequence(datum.cigars.length)"
+                        },
+                        {
+                            "flatten": [
+                                "cigars",
+                                "cigar_index"
+                            ]
+                        },
+                        {
+                            "calculate": "if(substring(datum.cigars, 0, 1) == 'i', 'insertion', if(substring(datum.cigars, length(datum.cigars) - 1, length(datum.cigars)) == '=', 'match', if(substring(datum.cigars, length(datum.cigars) - 1, length(datum.cigars)) == 'd', 'deletion', substring(datum.cigars, 1, length(datum.cigars)))))",
+                            "as": "type"
+                        },
+                        {
+                            "calculate": "if(datum.type == 'match' || datum.type == 'deletion', parseInt(substring(datum.cigars, 0, length(datum.cigars) - 1)), if(datum.type == 'insertion', 1, parseInt(substring(datum.cigars, 0, length(datum.cigars) - 1))))",
+                            "as": "length"
+                        },
+                        {
+                            "stack": "length",
+                            "groupby": [
+                                "name",
+                                "cigar",
+                                "position"
+                            ],
+                            "as": "offset"
+                        },
+                        {
+                            "as": "start",
+                            "calculate": "if(datum.type == 'insertion', datum.position + datum.offset + 1, datum.position + datum.offset + 0.5)"
+                        },
+                        {
+                            "as": "end",
+                            "calculate": "if(datum.type == 'insertion', datum.position + datum.offset + datum.length, datum.position + datum.offset + datum.length + 0.5)"
+                        },
+                        {
+                            "filter": "datum.type == 'deletion'"
+                        },
+                        {
+                            "as": "v_offset",
+                            "calculate": "if(datum.position < datum.mpos, 0, 2)"
+                        }
+                    ],
+                    "mark": {
+                        "type": "rule",
+                        "clip": true
+                    },
+                    "encoding": {
+                        "tooltip": [
+                            {
+                                "field": "name"
+                            },
+                            {
+                                "field": "type"
+                            },
+                            {
+                                "field": "mapq"
+                            },
+                            {
+                                "field": "flags"
+                            },
+                            {
+                                "field": "length"
+                            },
+                            {
+                                "field": "aux"
+                            },
+                            {
+                                "field": "raw_cigar"
+                            }
+                        ],
+                        "opacity": {
+                            "condition": {
+                                "param": "rplc",
+                                "value": 1
+                            },
+                            "value": 0.2
+                        },
+                        "strokeWidth": {
+                            "field": "type",
+                            "scale": {
+                                "type": "ordinal",
+                                "domain": [
+                                    "A",
+                                    "C",
+                                    "G",
+                                    "T",
+                                    "N",
+                                    "match",
+                                    "deletion",
+                                    "insertion"
+                                ],
+                                "range": [
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    6,
+                                    9
+                                ]
+                            },
+                            "legend": null
+                        },
+                        "color": {
+                            "field": "type",
+                            "legend": {
+                                "symbolSize": 75,
+                                "title": "symbol"
+                            },
+                            "scale": {
+                                "type": "ordinal",
+                                "domain": [
+                                    "A",
+                                    "C",
+                                    "G",
+                                    "T",
+                                    "N",
+                                    "match",
+                                    "deletion",
+                                    "insertion"
+                                ],
+                                "range": [
+                                    "#CADB69",
+                                    "#F2B671",
+                                    "#F28CC2",
+                                    "#7284A8",
+                                    "#A23E11",
+                                    "#BBBBBB",
+                                    "#CC1414",
+                                    "#047C0A"
+                                ]
+                            }
+                        }
                     }
                 }
-            }
+            ]
         }
     ]
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -65,6 +65,10 @@ pub struct Alignoth {
     #[structopt(long, parse(from_os_str), conflicts_with("output"))]
     pub(crate) read_data_output: Option<PathBuf>,
 
+    /// If present coverage data will be written to the given file path
+    #[structopt(long, parse(from_os_str), conflicts_with("output"))]
+    pub(crate) coverage_output: Option<PathBuf>,
+
     /// If present highlight data will be written to the given file path
     #[structopt(
         long,

--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -111,5 +111,6 @@ pub(crate) async fn wizard_mode() -> Result<Alignoth> {
         spec_output: None,
         ref_data_output: None,
         read_data_output: None,
+        coverage_output: None,
     })
 }


### PR DESCRIPTION
This PR adds a new coverage plot above the actual pileup visualization.

![visualization-9](https://github.com/user-attachments/assets/caaadc40-7067-4888-a643-471fcd55e303)
