### PR TITLE
perf: Compress specs using lz-string for HTML output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "inquire",
  "itertools 0.14.0",
  "log",
+ "lz-str",
  "rand 0.9.1",
  "reqwest",
  "rust-htslib",
@@ -1378,6 +1379,12 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "lz-str"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f3d72d77227090eed75ea331285a53726e78374a1f357ff5757702c23c70cc"
 
 [[package]]
 name = "lzma-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tera = "1.20.0"
 reqwest = "0.12" # 0.12 seems to cause issues fetching vega libs from cdn
 tokio = { version = "1", features = ["full"] }
 inquire = "0.7.5"
+lz-str = "0.2.1"
 
 [profile.release]
 lto = "fat"

--- a/resources/plot.html.tera
+++ b/resources/plot.html.tera
@@ -5,6 +5,7 @@
     <script>{{ vega | safe }}</script>
     <script>{{ vegalite | safe }}</script>
     <script>{{ vegaembed | safe }}</script>
+    <script>{{ lzstring | safe }}</script>
     <style>
         #controls {
             display: flex;
@@ -185,7 +186,8 @@
 </table>
 <div id="vis" style="display: flex; justify-content: center;"></div>
 <script>
-    const spec = {{ spec | safe }};
+    const compressed_spec = {{ spec | safe }};
+    const spec = JSON.parse(LZString.decompressFromUTF16(compressed_spec));
     let fullData = [];
     vegaEmbed("#vis", spec, {mode: "vega-lite"}).then(({ view }) => {
         fullReads = view.data('reads');

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use crate::wizard::wizard_mode;
 use anyhow::Result;
 use csv::WriterBuilder;
 use log::LevelFilter;
+use lz_str::compress_to_utf16;
 use serde_json::{json, Value};
 use simplelog::{ColorChoice, Config, TermLogger, TerminalMode};
 use std::cmp::min;
@@ -179,7 +180,10 @@ async fn main() -> Result<()> {
             let mut templates = Tera::default();
             templates.add_raw_template("plot", include_str!("../resources/plot.html.tera"))?;
             let mut context = Context::new();
-            context.insert("spec", &plot_specs.to_string());
+            context.insert(
+                "spec",
+                &json!(compress_to_utf16(&plot_specs.to_string())).to_string(),
+            );
             context.insert(
                 "vega",
                 &reqwest::get("https://cdn.jsdelivr.net/npm/vega@5")
@@ -197,6 +201,13 @@ async fn main() -> Result<()> {
             context.insert(
                 "vegaembed",
                 &reqwest::get("https://cdn.jsdelivr.net/npm/vega-embed@6")
+                    .await?
+                    .text()
+                    .await?,
+            );
+            context.insert(
+                "lzstring",
+                &reqwest::get("https://cdn.jsdelivr.net/npm/lz-string@1")
                     .await?
                     .text()
                     .await?,


### PR DESCRIPTION
This pull request introduces compression of Vega-Lite plot specifications using LZ-String to reduce the size of embedded data in the generated HTML visualizations. The changes include adding the necessary Rust and JavaScript libraries, updating the data flow to use compressed specs, and ensuring decompression on the client side for rendering. This improves efficiency and scalability when handling large plot specifications.