### PR TITLE
fix: Move subtitle to y axis title

### DIFF
--- a/resources/plot.vl.json
+++ b/resources/plot.vl.json
@@ -141,7 +141,15 @@
           "type": "quantitative"
         },
         "y": {
-          "axis": null,
+          "axis": {
+            "titleAnchor": "start",
+            "titleAlign": "right",
+            "titleFontWeight": 400,
+            "titlePadding": 28,
+            "labels": false,
+            "ticks": false,
+            "domain": false
+          },
           "field": "row",
           "type": "ordinal"
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,8 +64,8 @@ async fn main() -> Result<()> {
     };
     plot_specs["vconcat"][0]["title"] = json!({
             "text": &opt.region.unwrap().target,
-            "subtitle": subsampling_warning,
     });
+    plot_specs["vconcat"][1]["encoding"]["y"]["axis"]["title"] = json!(subsampling_warning);
     let reference = match opt.data_format {
         DataFormat::Json => json!(reference_data).to_string().as_bytes().to_vec(),
         DataFormat::Tsv => {


### PR DESCRIPTION
Just a minor change that moves the subtitle to the y axis title.