### PR TITLE
fix: Fixate stack order in coverage plot

### DIFF
--- a/resources/plot.vl.json
+++ b/resources/plot.vl.json
@@ -60,7 +60,8 @@
         {"calculate": "(toNumber(split(datum.c_raw, '|')[0]) + datum.start) == datum.position ? toNumber(split(datum.c_raw, '|')[1]) : 0", "as": "c"},
         {"aggregate": [{"op": "sum", "field": "c", "as": "c"}, {"op": "max", "field": "g", "as": "g"}, {"op": "max", "field": "t", "as": "t"}, {"op": "max", "field": "a", "as": "a"}, {"op": "max", "field": "m", "as": "m"}], "groupby": ["position"]},
         {"fold": ["m", "a", "c", "g", "t"], "as": ["base_type", "count"]},
-        {"calculate": "{'m': 'm', 'a': 'A', 'c': 'C', 'g': 'G', 't': 'T'}[datum.base_type]", "as": "base_label"}
+        {"calculate": "{'m': 'm', 'a': 'A', 'c': 'C', 'g': 'G', 't': 'T'}[datum.base_type]", "as": "base_label"},
+        {"calculate": "datum.base_label === 'm' ? 1 : 0", "as": "base_order"}
       ],
       "encoding": {
         "x": {
@@ -95,10 +96,7 @@
           },
           "legend": null
         },
-        "order": {
-          "field": "base_type",
-          "sort": ["m", "A", "C", "G", "T"]
-        }
+        "order": {"field": "base_order"}
       },
       "height": 60
     },


### PR DESCRIPTION
This pull request updates the base ordering logic in the `resources/plot.vl.json` visualization specification. The main change is a shift from manually sorting the base types to using a calculated field for ordering, which simplifies and clarifies the ordering mechanism.