### PR TITLE
fix: Create output directory if it does not exist

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -119,6 +119,9 @@ async fn main() -> Result<()> {
         }
     };
     if let Some(out_path) = &opt.output {
+        if !out_path.exists() {
+            std::fs::create_dir_all(out_path)?;
+        }
         let bam_path = opt.bam_path.unwrap();
         let bam_file_name = bam_path
             .file_name()


### PR DESCRIPTION
This pull request adds a check to ensure the output directory exists before writing output files. If the directory specified by `opt.output` does not exist, it will now be created automatically.

* Output Handling:
  * In `src/main.rs`, added logic to check if the output directory exists and create it if it does not, ensuring downstream operations do not fail due to missing directories.