### PR TITLE
fix: Make sure reference start is always interpreted as integer

### DIFF
--- a/resources/plot.vl.json
+++ b/resources/plot.vl.json
@@ -181,7 +181,7 @@
             },
             {
               "as": "position",
-              "calculate": "datum.start + datum.offset"
+              "calculate": "toNumber(datum.start) + datum.offset"
             },
             {
               "as": "start",


### PR DESCRIPTION
This pull request makes a small update to the calculation logic in the `resources/plot.vl.json` file. The change ensures that the `start` value is explicitly converted to a number before performing arithmetic, which can help prevent type-related issues in the visualization specification.