### PR TITLE
fix: Write highlight output if VCF or BED is provided

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,7 @@ async fn main() -> Result<()> {
             .unwrap()
             .strip_suffix(".bam")
             .unwrap();
-        let highlight_path = if opt.highlight.is_some() {
+        let highlight_path = if opt.highlight.is_some() || opt.vcf.is_some() || opt.bed.is_some() {
             Some(Path::join(
                 out_path,
                 format!("{}.highlight.{}", bam_file_name, opt.data_format),


### PR DESCRIPTION
This pull request updates the logic for determining when to generate a highlight file in `src/main.rs`. The change broadens the conditions under which a highlight file is created to include the presence of VCF or BED files, not just the highlight option.

Highlight file generation logic:

* The condition for creating a highlight file now checks if any of `opt.highlight`, `opt.vcf`, or `opt.bed` are provided, instead of only `opt.highlight`. (`[src/main.rsL133-R133](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL133-R133)`)