### PR TITLE
fix: Check for both .csi and .tbi VCF index files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -52,11 +52,10 @@ async fn main() -> Result<()> {
             highlight.extend(VcfHighlight::new(vcf_path.clone()).intervals(region)?);
         } else {
             bail!(
-                "VCF/BCF index not found: {} or {}. Please create an index using `bcftools index {}` or `tabix {}`.",
-                csi_index.display(),
-                tbi_index.display(),
-                vcf_path.display(),
-                vcf_path.display()
+                "VCF/BCF index not found: {csi} or {tbi}. Please create an index using `bcftools index {vcf}` or `tabix {vcf}`.",
+                csi = csi_index.display(),
+                tbi = tbi_index.display(),
+                vcf = vcf_path.display()
             );
         }
     }


### PR DESCRIPTION
This pull request improves the way VCF/BCF index files are detected in `src/main.rs`. Previously, the code only checked for the existence of a `.csi` index file. Now, it checks for both `.csi` and `.tbi` index files, providing more flexibility and better compatibility with different index formats.

Index file detection improvements:

* Updated logic to check for both `.csi` and `.tbi` index files before attempting to highlight intervals, instead of only `.csi`.
* Improved error message to mention both index file types (`.csi` and `.tbi`) if neither is found, guiding the user to create the appropriate index.