### PR TITLE
fix: Remove potential coverage plot offset at inital plot rendering

### DIFF
--- a/resources/plot.vl.json
+++ b/resources/plot.vl.json
@@ -2,7 +2,8 @@
   "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
   "resolve": {
     "scale": {
-      "strokeWidth": "independent"
+      "strokeWidth": "independent",
+      "x": "shared"
     }
   },
   "datasets": {


### PR DESCRIPTION
This pull request makes a minor update to the Vega-Lite plot configuration by adjusting the scale resolution settings.

* Visualization configuration: The `x` scale is now set to `"shared"` in the `resolve.scale` section of `resources/plot.vl.json`, which will synchronize the x-axis across layered or faceted plots.