### PR TITLE
perf: Simplify Vega transforms for coverage base counts

### DIFF
--- a/resources/plot.vl.json
+++ b/resources/plot.vl.json
@@ -35,10 +35,6 @@
       },
       "transform": [
         {"calculate": "split(datum.m, '|')", "as": "m"},
-        {"calculate": "split(datum.a, '$')", "as": "a_raw"},
-        {"calculate": "split(datum.t, '$')", "as": "t_raw"},
-        {"calculate": "split(datum.g, '$')", "as": "g_raw"},
-        {"calculate": "split(datum.c, '$')", "as": "c_raw"},
         {"flatten": ["m"]},
         {
           "window": [
@@ -48,18 +44,15 @@
           "frame": [null, 0]
         },
         {"calculate": "toNumber(datum.start) + datum.index", "as": "position"},
-        {"flatten": ["a_raw"]},
-        {"calculate": "(toNumber(split(datum.a_raw, '|')[0]) + toNumber(datum.start)) == datum.position ? toNumber(split(datum.a_raw, '|')[1]) : 0", "as": "a"},
-        {"aggregate": [{"op": "sum", "field": "a", "as": "a"}, {"op": "max", "field": "m", "as": "m"}], "groupby": ["position", "t_raw", "g_raw", "c_raw", "start"]},
-        {"flatten": ["t_raw"]},
-        {"calculate": "(toNumber(split(datum.t_raw, '|')[0]) + toNumber(datum.start)) == datum.position ? toNumber(split(datum.t_raw, '|')[1]) : 0", "as": "t"},
-        {"aggregate": [{"op": "sum", "field": "t", "as": "t"}, {"op": "max", "field": "a", "as": "a"}, {"op": "max", "field": "m", "as": "m"}], "groupby": ["position", "g_raw", "c_raw", "start"]},
-        {"flatten": ["g_raw"]},
-        {"calculate": "(toNumber(split(datum.g_raw, '|')[0]) + toNumber(datum.start)) == datum.position ? toNumber(split(datum.g_raw, '|')[1]) : 0", "as": "g"},
-        {"aggregate": [{"op": "sum", "field": "g", "as": "g"}, {"op": "max", "field": "t", "as": "t"}, {"op": "max", "field": "a", "as": "a"}, {"op": "max", "field": "m", "as": "m"}], "groupby": ["position", "c_raw", "start"]},
-        {"flatten": ["c_raw"]},
-        {"calculate": "(toNumber(split(datum.c_raw, '|')[0]) + toNumber(datum.start)) == datum.position ? toNumber(split(datum.c_raw, '|')[1]) : 0", "as": "c"},
-        {"aggregate": [{"op": "sum", "field": "c", "as": "c"}, {"op": "max", "field": "g", "as": "g"}, {"op": "max", "field": "t", "as": "t"}, {"op": "max", "field": "a", "as": "a"}, {"op": "max", "field": "m", "as": "m"}], "groupby": ["position"]},
+        {"calculate": "toString(datum.position - toNumber(datum.start)) + '|'", "as": "search_key"},
+        {"calculate": "indexof(datum.a, datum.search_key)", "as": "a_idx"},
+        {"calculate": "datum.a_idx >= 0 ? toNumber(split(split(slice(datum.a, datum.a_idx), '$')[0], '|')[1]) : 0", "as": "a"},
+        {"calculate": "indexof(datum.t, datum.search_key)", "as": "t_idx"},
+        {"calculate": "datum.t_idx >= 0 ? toNumber(split(split(slice(datum.t, datum.t_idx), '$')[0], '|')[1]) : 0", "as": "t"},
+        {"calculate": "indexof(datum.g, datum.search_key)", "as": "g_idx"},
+        {"calculate": "datum.g_idx >= 0 ? toNumber(split(split(slice(datum.g, datum.g_idx), '$')[0], '|')[1]) : 0", "as": "g"},
+        {"calculate": "indexof(datum.c, datum.search_key)", "as": "c_idx"},
+        {"calculate": "datum.c_idx >= 0 ? toNumber(split(split(slice(datum.c, datum.c_idx), '$')[0], '|')[1]) : 0", "as": "c"},
         {"fold": ["m", "a", "c", "g", "t"], "as": ["base_type", "count"]},
         {"calculate": "{'m': 'm', 'a': 'A', 'c': 'C', 'g': 'G', 't': 'T'}[datum.base_type]", "as": "base_label"},
         {"calculate": "datum.base_label === 'm' ? 1 : 0", "as": "base_order"}


### PR DESCRIPTION
This pull request refactors the transformation logic in the `resources/plot.vl.json` file to simplify and optimize how base counts (`a`, `t`, `g`, `c`) are extracted and calculated. The previous approach used multiple `split`, `flatten`, and `aggregate` operations for each base type, which has now been replaced with a more concise method that uses index searching and direct calculation. This should make the transformation pipeline easier to maintain and potentially improve performance.

**Refactoring and simplification of transformation logic:**

* Removed multiple `split`, `flatten`, and `aggregate` steps for extracting and aggregating base counts (`a`, `t`, `g`, `c`), reducing complexity in the transformation pipeline. [[1]](diffhunk://#diff-d204823b3908b09b543221054fdd32ffe20e1896c7387b7328ea963b5a0d296cL38-L41) [[2]](diffhunk://#diff-d204823b3908b09b543221054fdd32ffe20e1896c7387b7328ea963b5a0d296cL51-R55)
* Introduced a new approach that calculates a `search_key` for each position, finds the index of each base type in its respective string, and directly extracts the count using conditional logic and string slicing.