### PR TITLE
fix: Allow .vcf files in wizard mode

### DIFF
--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -31,7 +31,7 @@ pub(crate) async fn wizard_mode() -> Result<Alignoth> {
         .map(|e| e.path())
         .filter(|p| {
             p.extension()
-                .is_some_and(|ext| ext == "vcf.gz" || ext == "bcf")
+                .is_some_and(|ext| ext == "vcf.gz" || ext == "bcf" || ext == "vcf")
         })
         .collect();
     let bed_files: Vec<_> = fs::read_dir(&current_dir)?


### PR DESCRIPTION
This pull request makes alignoth also recognize files with the `.vcf` extension, in addition to the previously supported `.vcf.gz` and `.bcf` extensions.