### PR TITLE
feat: Add option to clamp reads to region

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The following options are available when using alignoth:
 | no-embed-js           |       | If present, the generated html will not embed javscript dependencies and therefore be considerably smaller but require internet access to load the dependencies.  | false   |
 | around-vcf-record     | -a    | Plots a region around a specified VCF record taken via its index (starting at 0) from the VCF file given via the --vcf option.                                                    |         |
 | mismatch-display-min-percent |     | The minimum percentage of mismatches to display in the coverage plot.                                                                                        | 1       |
+| clamp-reads           |       | If set, reads are clamped to the boundaries of the specified region before processing. Useful with very long reads to avoid including read data far outside the region. | false   |
 
 
 ## Installation

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -110,6 +110,10 @@ pub struct Alignoth {
     /// The minimum percentage of mismatches compared to total read depth at that point to display in the coverage plot.
     #[structopt(long, default_value = "1.0")]
     pub(crate) mismatch_display_min_percent: f64,
+
+    /// If set, reads are clamped to the boundaries of the specified region before processing.
+    #[structopt(long)]
+    pub(crate) clamp_reads: bool,
 }
 
 pub(crate) trait Preprocess {

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ async fn main() -> Result<()> {
         opt.max_read_depth,
         opt.aux_tag,
         opt.mismatch_display_min_percent,
+        opt.clamp_reads,
     )?;
     let mut highlight = opt.highlight.as_ref().cloned().unwrap_or_default();
     if let Some(vcf_path) = opt.vcf.as_ref() {

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -29,6 +29,7 @@ pub(crate) fn create_plot_data<P: AsRef<Path> + std::fmt::Debug>(
     max_read_depth: usize,
     aux_tags: Option<Vec<String>>,
     mismatch_display_min_percent: f64,
+    clamp_reads: bool,
 ) -> Result<(Vec<EncodedRead>, Reference, usize, Coverage, usize)> {
     let mut bam = bam::IndexedReader::from_path(&bam_path)?;
     let tid = bam
@@ -44,6 +45,17 @@ pub(crate) fn create_plot_data<P: AsRef<Path> + std::fmt::Debug>(
         .records()
         .filter_map(|r| r.ok())
         .filter_map(|r| {
+            let r = if clamp_reads {
+                match clip_read(r, region.start, region.end) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        warn!("Skipping read during region clamping: {e}");
+                        return None;
+                    }
+                }
+            } else {
+                r
+            };
             Read::from_record(r, &ref_path, &region.target, &aux_tags)
                 .context(format!(
                     "bam file does not contain given region target {}",
@@ -559,13 +571,14 @@ fn match_bases(read_seq: &[char], ref_seq: &[char]) -> Vec<InnerPlotCigar> {
 
 fn clip_read(
     mut record: rust_htslib::bam::record::Record,
-    upper_bound: usize,
+    lower_bound: i64,
+    upper_bound: i64,
 ) -> Result<rust_htslib::bam::record::Record> {
     let read_start = record.pos() - record.cigar().leading_softclips();
     let read_end = record.reference_end() + record.cigar().trailing_softclips();
 
-    let bases_to_trim_start = read_start.min(0).unsigned_abs() as usize;
-    let bases_to_trim_end = (read_end - upper_bound as i64).max(0) as usize;
+    let bases_to_trim_start = (lower_bound - read_start).max(0) as usize;
+    let bases_to_trim_end = (read_end - upper_bound).max(0) as usize;
 
     let cigar = record.cigar();
     let cigar_len = cigar.len();
@@ -635,7 +648,7 @@ impl Read {
         let read_end = record.reference_end() + record.cigar().trailing_softclips();
 
         let record = if read_start < 0 || read_end > ref_length as i64 {
-            clip_read(record, ref_length)?
+            clip_read(record, 0, ref_length as i64)?
         } else {
             record
         };
@@ -891,6 +904,7 @@ mod tests {
             500,
             None,
             0.0,
+            false,
         )
         .unwrap();
 
@@ -1024,6 +1038,7 @@ mod tests {
             100,
             None,
             0.0,
+            false,
         )
         .unwrap();
         let expected_reference = Reference {
@@ -1074,6 +1089,7 @@ mod tests {
             500,
             None,
             0.0,
+            false,
         );
         assert!(result.is_ok());
     }
@@ -1092,6 +1108,7 @@ mod tests {
             500,
             None,
             0.0,
+            false,
         );
         assert!(result.is_ok());
     }

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -45,18 +45,7 @@ pub(crate) fn create_plot_data<P: AsRef<Path> + std::fmt::Debug>(
         .records()
         .filter_map(|r| r.ok())
         .filter_map(|r| {
-            let r = if clamp_reads {
-                match clip_read(r, region.start, region.end) {
-                    Ok(r) => r,
-                    Err(e) => {
-                        warn!("Skipping read during region clamping: {e}");
-                        return None;
-                    }
-                }
-            } else {
-                r
-            };
-            Read::from_record(r, &ref_path, &region.target, &aux_tags)
+            Read::from_record(r, &ref_path, &aux_tags, region, clamp_reads)
                 .context(format!(
                     "bam file does not contain given region target {}",
                     &region.target
@@ -684,8 +673,9 @@ impl Read {
     fn from_record<P: AsRef<Path> + std::fmt::Debug>(
         record: rust_htslib::bam::record::Record,
         ref_path: P,
-        target: &str,
         aux_tags: &Option<Vec<String>>,
+        region: &Region,
+        clamp: bool,
     ) -> Result<Option<Read>> {
         let read_seq = record
             .seq()
@@ -701,17 +691,20 @@ impl Read {
             );
             return Ok(None);
         }
-        let ref_length = get_fasta_length(&ref_path.as_ref().to_path_buf(), target)?;
+        let ref_length = get_fasta_length(&ref_path.as_ref().to_path_buf(), &region.target)?;
         let read_start = record.pos() - record.cigar().leading_softclips();
         let read_end = record.reference_end() + record.cigar().trailing_softclips();
 
-        let record = if read_start < 0 || read_end > ref_length as i64 {
-            clip_read(record, 0, ref_length as i64)?
+        let lower_bound = if clamp { region.start } else { 0 };
+        let upper_bound = if clamp { region.end } else { ref_length as i64 };
+
+        let record = if read_start < lower_bound || read_end > upper_bound {
+            clip_read(record, lower_bound, upper_bound)?
         } else {
             record
         };
         let region = cli::Region {
-            target: target.to_string(),
+            target: region.target.clone(),
             start: record.pos() - record.cigar().leading_softclips(),
             end: record.reference_end() + record.cigar().trailing_softclips(),
         };

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -574,49 +574,107 @@ fn clip_read(
     lower_bound: i64,
     upper_bound: i64,
 ) -> Result<rust_htslib::bam::record::Record> {
-    let read_start = record.pos() - record.cigar().leading_softclips();
-    let read_end = record.reference_end() + record.cigar().trailing_softclips();
-
-    let bases_to_trim_start = (lower_bound - read_start).max(0) as usize;
-    let bases_to_trim_end = (read_end - upper_bound).max(0) as usize;
-
     let cigar = record.cigar();
-    let cigar_len = cigar.len();
-    let new_cigar: Vec<_> = cigar
-        .iter()
-        .enumerate()
-        .filter_map(|(i, c)| match c {
-            Cigar::SoftClip(len) => {
-                let mut new_len = *len as usize;
-                if i == 0 {
-                    new_len = new_len.saturating_sub(bases_to_trim_start);
-                }
-                if i == cigar_len - 1 {
-                    new_len = new_len.saturating_sub(bases_to_trim_end);
-                }
-                (new_len > 0).then_some(Cigar::SoftClip(new_len as u32))
-            }
-            _ => Some(*c),
-        })
-        .collect();
-
     let seq = record.seq().as_bytes();
     let qual = record.qual().to_vec();
-    let seq_len = seq.len();
+    let qname = record.qname().to_vec();
 
-    let trim_start = bases_to_trim_start.min(seq_len);
-    let trim_end = seq_len - bases_to_trim_end.min(seq_len.saturating_sub(trim_start));
+    let mut new_cigar = Vec::with_capacity(cigar.len());
+    let mut new_seq = Vec::with_capacity(seq.len());
+    let mut new_qual = Vec::with_capacity(qual.len());
 
-    let new_seq = seq[trim_start..trim_end].to_vec();
-    let new_qual = qual[trim_start..trim_end].to_vec();
+    let mut ref_pos = record.pos() - cigar.leading_softclips();
+    let mut seq_pos = 0;
+    let mut new_read_start = None;
 
-    let new_cigar_string = CigarString::from(new_cigar);
+    let mut extend_query_data = |start: usize, end: usize| {
+        if !seq.is_empty() {
+            new_seq.extend_from_slice(&seq[start..end]);
+        }
+        if !qual.is_empty() {
+            new_qual.extend_from_slice(&qual[start..end]);
+        }
+    };
+
+    for &c in cigar.iter() {
+        let op_len = c.len() as usize;
+
+        let (consumes_ref, consumes_query) = match c {
+            Cigar::Match(_) | Cigar::Equal(_) | Cigar::Diff(_) | Cigar::SoftClip(_) => (true, true),
+            Cigar::Del(_) | Cigar::RefSkip(_) => (true, false),
+            Cigar::Ins(_) => (false, true),
+            Cigar::HardClip(_) | Cigar::Pad(_) => (false, false),
+        };
+
+        let next_ref_pos = ref_pos + if consumes_ref { op_len as i64 } else { 0 };
+        let next_seq_pos = seq_pos + if consumes_query { op_len } else { 0 };
+
+        if !consumes_ref {
+            if ref_pos >= lower_bound && ref_pos < upper_bound {
+                new_read_start.get_or_insert(ref_pos);
+                new_cigar.push(c);
+                if consumes_query {
+                    extend_query_data(seq_pos, next_seq_pos);
+                }
+            }
+        } else {
+            let overlap_start = ref_pos.max(lower_bound);
+            let overlap_end = next_ref_pos.min(upper_bound);
+
+            if overlap_start < overlap_end {
+                new_read_start.get_or_insert(overlap_start);
+
+                let left_trim = (overlap_start - ref_pos) as usize;
+                let right_trim = (next_ref_pos - overlap_end) as usize;
+                let new_op_len = op_len - left_trim - right_trim;
+
+                if new_op_len > 0 {
+                    let new_op = match c {
+                        Cigar::Match(_) => Cigar::Match(new_op_len as u32),
+                        Cigar::Del(_) => Cigar::Del(new_op_len as u32),
+                        Cigar::RefSkip(_) => Cigar::RefSkip(new_op_len as u32),
+                        Cigar::SoftClip(_) => Cigar::SoftClip(new_op_len as u32),
+                        Cigar::Equal(_) => Cigar::Equal(new_op_len as u32),
+                        Cigar::Diff(_) => Cigar::Diff(new_op_len as u32),
+                        _ => unreachable!(),
+                    };
+                    new_cigar.push(new_op);
+
+                    if consumes_query {
+                        extend_query_data(seq_pos + left_trim, next_seq_pos - right_trim);
+                    }
+                }
+            }
+        }
+
+        ref_pos = next_ref_pos;
+        seq_pos = next_seq_pos;
+    }
+
     record.set(
-        &record.qname().to_vec(),
-        Some(&new_cigar_string),
+        &qname,
+        Some(&CigarString::from(new_cigar.clone())),
         &new_seq,
         &new_qual,
     );
+
+    if let Some(start) = new_read_start {
+        let new_leading_softclips: i64 = new_cigar
+            .iter()
+            .take_while(|c| matches!(c, Cigar::SoftClip(_) | Cigar::HardClip(_)))
+            .filter_map(|c| {
+                if let Cigar::SoftClip(l) = c {
+                    Some(*l as i64)
+                } else {
+                    None
+                }
+            })
+            .sum();
+
+        record.set_pos(start + new_leading_softclips);
+    } else {
+        record.set_pos(lower_bound);
+    }
 
     Ok(record)
 }

--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -86,6 +86,11 @@ pub(crate) async fn wizard_mode() -> Result<Alignoth> {
         _ => unreachable!(),
     };
 
+    let clamp_reads: bool = Text::new("Clamp reads to the specified region?")
+        .with_default("false")
+        .prompt()?
+        .parse()?;
+
     let target_length = get_fasta_length(&PathBuf::from(reference_path.clone()), &target)? as i64;
     region = region.clamp(0, target_length - 1);
     let highlight_input = Text::new("Do you want to highlight a specific region or position? (Example: some_interval:1000-2000 or some_position:1200, press Enter to skip)").prompt()?;
@@ -176,5 +181,6 @@ pub(crate) async fn wizard_mode() -> Result<Alignoth> {
         coverage_output: None,
         no_embed_js: false,
         mismatch_display_min_percent: 1.0,
+        clamp_reads,
     })
 }


### PR DESCRIPTION
If you request only a certain region but you have very long reads, all of the read data is still included in the vega lite plot, which can cause huge slow downs. This PR introduces a `--clamp-reads` option that clips the read data to the requested region.