### PR TITLE
refactor: Remove deprecated choose_multiple and replace with sample

### DIFF
--- a/src/plot.rs
+++ b/src/plot.rs
@@ -708,7 +708,7 @@ impl PlotOrder for Vec<Read> {
             if max_read_depth < *used_rows {
                 let mut rng = StdRng::seed_from_u64(42);
                 let random_rows: HashSet<_> = (0..*used_rows as u32)
-                    .choose_multiple(&mut rng, max_read_depth)
+                    .sample(&mut rng, max_read_depth)
                     .into_iter()
                     .collect();
                 self.retain(|read| random_rows.contains(&read.row.unwrap()));


### PR DESCRIPTION
Replaces the use of the deprecated `choose_multiple` with `sample` for selecting a subset of rows.