### PR TITLE
feat: Retry individual wizard prompts on invalid input

### DIFF
--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -2,6 +2,7 @@ use crate::cli::{Alignoth, Around, Clamp, FromAround, Interval, Region};
 use crate::utils::{get_fasta_contigs, get_fasta_length};
 use anyhow::Result;
 use inquire::{Select, Text};
+use std::fmt::Display;
 use std::fs;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -69,14 +70,14 @@ pub(crate) async fn wizard_mode() -> Result<Alignoth> {
     {
         "Around a position" => {
             let around = Around {
-                position: Text::new("Position:").prompt()?.parse()?,
+                position: prompt_parse("Position:", None)?,
                 target: target.clone(),
             };
             Region::from_around(&around)
         }
         "Region" => {
-            let start: i64 = Text::new("Start coordinate:").prompt()?.parse()?;
-            let end = Text::new("End coordinate:").prompt()?.parse()?;
+            let start: i64 = prompt_parse("Start coordinate:", None)?;
+            let end: i64 = prompt_parse("End coordinate:", None)?;
             Region {
                 target: target.clone(),
                 start: start - 1, // Adjust for 1-based
@@ -98,12 +99,8 @@ pub(crate) async fn wizard_mode() -> Result<Alignoth> {
         "path/to/file.bed",
         &bed_files,
     )?;
-    let highlight_input = Text::new("Do you want to highlight a specific region or position? (Example: some_interval:1000-2000 or some_position:1200, press Enter to skip)").prompt()?;
-    let highlight = if highlight_input.is_empty() {
-        None
-    } else {
-        Some(vec![Interval::from_str(&highlight_input)?])
-    };
+    let highlight = prompt_parse_optional::<Interval>("Do you want to highlight a specific region or position? (Example: some_interval:1000-2000 or some_position:1200, press Enter to skip)")?
+        .map(|interval| vec![interval]);
     let aux_tag_input =
         Text::new("Optional auxiliary tags (whitespace-separated, press Enter to skip):")
             .prompt_skippable()?;
@@ -116,9 +113,7 @@ pub(crate) async fn wizard_mode() -> Result<Alignoth> {
         }
     });
 
-    let max_depth = Text::new("Max read depth (default 500):")
-        .with_default("500")
-        .prompt()?;
+    let max_read_depth: usize = prompt_parse("Max read depth (default 500):", Some("500"))?;
 
     let html_output = Select::new(
         "Choose output type:",
@@ -132,7 +127,7 @@ pub(crate) async fn wizard_mode() -> Result<Alignoth> {
         reference: Some(reference_path.into()),
         region: Some(region),
         aux_tag: aux_tags,
-        max_read_depth: max_depth.parse()?,
+        max_read_depth,
         max_width: 1024,
         output: None,
         data_format: Default::default(),
@@ -171,5 +166,42 @@ fn select_optional_file(
         choices.push("Skip".to_string());
         let selection = Select::new(question, choices).prompt()?;
         Ok((selection != "Skip").then(|| PathBuf::from(&selection)))
+    }
+}
+
+/// Prompts with `message`, re-asking until the input parses into `T` instead of aborting the
+/// wizard on a parse error. An optional `default` pre-fills the prompt.
+fn prompt_parse<T>(message: &str, default: Option<&str>) -> Result<T>
+where
+    T: FromStr,
+    T::Err: Display,
+{
+    loop {
+        let mut prompt = Text::new(message);
+        if let Some(default) = default {
+            prompt = prompt.with_default(default);
+        }
+        match prompt.prompt()?.parse() {
+            Ok(value) => return Ok(value),
+            Err(error) => eprintln!("Invalid input: {error}. Please try again."),
+        }
+    }
+}
+
+/// Like [`prompt_parse`], but treats empty input as `None` so the user can skip the prompt.
+fn prompt_parse_optional<T>(message: &str) -> Result<Option<T>>
+where
+    T: FromStr,
+    T::Err: Display,
+{
+    loop {
+        let input = Text::new(message).prompt()?;
+        if input.trim().is_empty() {
+            return Ok(None);
+        }
+        match input.parse() {
+            Ok(value) => return Ok(Some(value)),
+            Err(error) => eprintln!("Invalid input: {error}. Please try again."),
+        }
     }
 }

--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -88,47 +88,21 @@ pub(crate) async fn wizard_mode() -> Result<Alignoth> {
 
     let target_length = get_fasta_length(&PathBuf::from(reference_path.clone()), &target)? as i64;
     region = region.clamp(0, target_length - 1);
+    let vcf_input = select_optional_file(
+        "Do you want to provide a VCF file to highlight variant positions?",
+        "path/to/file.vcf",
+        &vcf_files,
+    )?;
+    let bed_input = select_optional_file(
+        "Do you want to provide a BED file to highlight certain regions?",
+        "path/to/file.bed",
+        &bed_files,
+    )?;
     let highlight_input = Text::new("Do you want to highlight a specific region or position? (Example: some_interval:1000-2000 or some_position:1200, press Enter to skip)").prompt()?;
     let highlight = if highlight_input.is_empty() {
         None
     } else {
         Some(vec![Interval::from_str(&highlight_input)?])
-    };
-    let vcf_choices: Vec<_> = vcf_files.iter().map(|p| p.display().to_string()).collect();
-    let vcf_input: Option<PathBuf> = if vcf_choices.is_empty() {
-        let input = Text::new("Do you want to provide a VCF file to highlight variant positions? (Example: path/to/file.vcf, press Enter to skip)").prompt()?;
-        if input.is_empty() {
-            None
-        } else {
-            Some(PathBuf::from(input))
-        }
-    } else {
-        let mut choices = vcf_choices.clone();
-        choices.push("Skip".to_string());
-        let selection = Select::new("Choose a VCF file:", choices).prompt()?;
-        if selection == "Skip" {
-            None
-        } else {
-            Some(PathBuf::from(selection))
-        }
-    };
-    let bed_choices: Vec<_> = bed_files.iter().map(|p| p.display().to_string()).collect();
-    let bed_input: Option<PathBuf> = if bed_choices.is_empty() {
-        let input = Text::new("Do you want to provide a BED file to highlight certain regions? (Example: path/to/file.bed, press Enter to skip)").prompt()?;
-        if input.is_empty() {
-            None
-        } else {
-            Some(PathBuf::from(input))
-        }
-    } else {
-        let mut choices = bed_choices.clone();
-        choices.push("Skip".to_string());
-        let selection = Select::new("Choose a BED file:", choices).prompt()?;
-        if selection == "Skip" {
-            None
-        } else {
-            Some(PathBuf::from(selection))
-        }
     };
     let aux_tag_input =
         Text::new("Optional auxiliary tags (whitespace-separated, press Enter to skip):")
@@ -177,4 +151,25 @@ pub(crate) async fn wizard_mode() -> Result<Alignoth> {
         no_embed_js: false,
         mismatch_display_min_percent: 1.0,
     })
+}
+
+/// Asks the user for an optional file, letting them pick from `candidates` found in the current
+/// directory or enter a path manually. Returns `None` if the user chooses to skip.
+fn select_optional_file(
+    question: &str,
+    example: &str,
+    candidates: &[PathBuf],
+) -> Result<Option<PathBuf>> {
+    if candidates.is_empty() {
+        let input = Text::new(&format!(
+            "{question} (Example: {example}, press Enter to skip)"
+        ))
+        .prompt()?;
+        Ok((!input.trim().is_empty()).then(|| PathBuf::from(input.trim())))
+    } else {
+        let mut choices: Vec<_> = candidates.iter().map(|p| p.display().to_string()).collect();
+        choices.push("Skip".to_string());
+        let selection = Select::new(question, choices).prompt()?;
+        Ok((selection != "Skip").then(|| PathBuf::from(&selection)))
+    }
 }


### PR DESCRIPTION
This PR makes the wizard re-ask an individual prompt when its input fails to parse instead of aborting the whole session, via two generic `prompt_parse`/`prompt_parse_optional` helpers applied to the position, region coordinate, highlight, and max-read-depth prompts.