### PR TITLE
feat: Offer to create missing BAM/FASTA/VCF indexes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "serde_json",
  "simplelog",
  "structopt",
+ "tempfile",
  "tera",
  "tokio",
 ]
@@ -126,7 +127,7 @@ dependencies = [
  "enum-map",
  "fxhash",
  "getset",
- "itertools 0.12.1",
+ "itertools 0.15.0",
  "itertools-num",
  "multimap",
  "ndarray",
@@ -653,6 +654,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "feature-probe"
@@ -2144,6 +2151,19 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ tokio = { version = "1", features = ["full"] }
 inquire = "0.9.4"
 lz-str = "0.2.1"
 
+[dev-dependencies]
+tempfile = "3"
+
 [profile.release]
 lto = "fat"
 codegen-units = 1

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,6 @@
-use crate::utils::{get_fasta_length, get_ref_and_bam_from_cwd};
+use crate::utils::{
+    ensure_bam_index, ensure_fasta_index, get_fasta_length, get_ref_and_bam_from_cwd,
+};
 use anyhow::{anyhow, Context, Result};
 use log::warn;
 use rust_htslib::bam;
@@ -152,6 +154,10 @@ impl Preprocess for Alignoth {
                 "Missing reference file. Please use the -r flag to specify the reference file."
             ));
         }
+        for bam in &self.bam_path {
+            ensure_bam_index(bam)?;
+        }
+        ensure_fasta_index(self.reference.as_ref().unwrap())?;
         if self.plot_all {
             warn!("You are using the --plot-all option. This is not recommended for large bam files or files with multiple targets.");
             let mut min_start = i64::MAX;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,9 @@ mod wizard;
 use crate::cli::{DataFormat, Preprocess};
 use crate::highlight::{BedHighlight, Highlight, VcfHighlight};
 use crate::plot::create_plot_data;
+use crate::utils::ensure_vcf_index;
 use crate::wizard::wizard_mode;
-use anyhow::{bail, Result};
+use anyhow::Result;
 use csv::WriterBuilder;
 use log::LevelFilter;
 use lz_str::compress_to_utf16;
@@ -177,18 +178,8 @@ async fn main() -> Result<()> {
     };
     let mut highlight = opt.highlight.as_ref().cloned().unwrap_or_default();
     if let Some(vcf_path) = opt.vcf.as_ref() {
-        let csi_index = PathBuf::from(&format!("{}.csi", vcf_path.display()));
-        let tbi_index = PathBuf::from(&format!("{}.tbi", vcf_path.display()));
-        if csi_index.exists() || tbi_index.exists() {
-            highlight.extend(VcfHighlight::new(vcf_path.clone()).intervals(region)?);
-        } else {
-            bail!(
-                "VCF/BCF index not found: {csi} or {tbi}. Please create an index using `bcftools index {vcf}` or `tabix {vcf}`.",
-                csi = csi_index.display(),
-                tbi = tbi_index.display(),
-                vcf = vcf_path.display()
-            );
-        }
+        let vcf_path = ensure_vcf_index(vcf_path)?;
+        highlight.extend(VcfHighlight::new(vcf_path).intervals(region)?);
     }
     if let Some(bed_path) = opt.bed.as_ref() {
         highlight.extend(BedHighlight::new(bed_path.clone()).intervals(region)?);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,10 @@
-use anyhow::Result;
+use anyhow::{anyhow, Context, Result};
 use bio::io::fasta;
 use itertools::Itertools;
+use rust_htslib::bcf::{Format, Header, Read as BcfRead, Reader, Writer};
+use rust_htslib::{bam, bcf};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 // Check if the cwd contains only one fasta (.fa, .fasta, .fasta.gz, .fa.gz) file and at least one bam (.bam, .bam.gz) file. Returns the fasta path and a vector of all bam paths.
 pub(crate) fn get_ref_and_bam_from_cwd() -> Result<Option<(PathBuf, Vec<PathBuf>)>> {
@@ -52,6 +54,103 @@ pub(crate) fn get_fasta_contigs(fasta_path: &PathBuf) -> Result<Vec<String>> {
     Ok(contigs)
 }
 
+/// Returns `path` with `.extension` appended, e.g. `reads.bam` + `bai` -> `reads.bam.bai`.
+fn appended_extension(path: &Path, extension: &str) -> PathBuf {
+    let mut name = path.as_os_str().to_owned();
+    name.push(".");
+    name.push(extension);
+    PathBuf::from(name)
+}
+
+/// Returns whether a coordinate index (`.bai` or `.csi`) exists next to the given BAM/CRAM file.
+pub(crate) fn bam_index_present(path: &Path) -> bool {
+    appended_extension(path, "bai").exists() || appended_extension(path, "csi").exists()
+}
+
+/// Builds a `.bai` index for the given (coordinate-sorted) BAM/CRAM file.
+pub(crate) fn build_bam_index(path: &Path) -> Result<()> {
+    bam::index::build(path, None, bam::index::Type::Bai, 1).with_context(|| {
+        format!(
+            "Failed to build index for {}. Is the file coordinate-sorted?",
+            path.display()
+        )
+    })
+}
+
+/// Returns whether a `.fai` index exists next to the given FASTA file.
+pub(crate) fn fasta_index_present(path: &Path) -> bool {
+    appended_extension(path, "fai").exists()
+}
+
+/// Builds a `.fai` index for the given FASTA file.
+pub(crate) fn build_fasta_index(path: &Path) -> Result<()> {
+    rust_htslib::faidx::build(path)
+        .map_err(|e| anyhow!("Failed to build index for {}: {e}", path.display()))
+}
+
+/// Returns whether a `.tbi` or `.csi` index exists next to the given VCF/BCF file.
+pub(crate) fn vcf_index_present(path: &Path) -> bool {
+    appended_extension(path, "tbi").exists() || appended_extension(path, "csi").exists()
+}
+
+/// Builds an index for the given VCF/BCF file, bgzipping a plain `.vcf` first if necessary.
+/// Returns the path that should be used downstream (unchanged, or the newly written `.vcf.gz`).
+pub(crate) fn build_vcf_index(path: &Path) -> Result<PathBuf> {
+    let name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or_default();
+    if name.ends_with(".bcf") {
+        bcf::index::build(path, None, 1, bcf::index::Type::Csi(14))?;
+        Ok(path.to_path_buf())
+    } else if name.ends_with(".vcf.gz") {
+        bcf::index::build(path, None, 1, bcf::index::Type::Tbx)?;
+        Ok(path.to_path_buf())
+    } else {
+        let bgzipped = bgzip_vcf(path)?;
+        bcf::index::build(&bgzipped, None, 1, bcf::index::Type::Tbx)?;
+        Ok(bgzipped)
+    }
+}
+
+/// Rewrites an uncompressed VCF as a bgzipped `.vcf.gz` next to it and returns the new path.
+fn bgzip_vcf(path: &Path) -> Result<PathBuf> {
+    let mut reader = Reader::from_path(path)?;
+    let header = Header::from_template(reader.header());
+    let output = appended_extension(path, "gz");
+    let mut writer = Writer::from_path(&output, &header, false, Format::Vcf)?;
+    for record in reader.records() {
+        writer.write(&record?)?;
+    }
+    Ok(output)
+}
+
+/// Ensures a coordinate index exists for the given BAM/CRAM file, building one if it is missing.
+pub(crate) fn ensure_bam_index(path: &Path) -> Result<()> {
+    if !bam_index_present(path) {
+        build_bam_index(path)?;
+    }
+    Ok(())
+}
+
+/// Ensures a `.fai` index exists for the given FASTA file, building one if it is missing.
+pub(crate) fn ensure_fasta_index(path: &Path) -> Result<()> {
+    if !fasta_index_present(path) {
+        build_fasta_index(path)?;
+    }
+    Ok(())
+}
+
+/// Ensures an index exists for the given VCF/BCF file, building one (and bgzipping a plain `.vcf`
+/// if necessary) when it is missing. Returns the path that should be used downstream.
+pub(crate) fn ensure_vcf_index(path: &Path) -> Result<PathBuf> {
+    if vcf_index_present(path) {
+        Ok(path.to_path_buf())
+    } else {
+        build_vcf_index(path)
+    }
+}
+
 /// Takes any given aux and returns a string representation of it.
 pub(crate) fn aux_to_string(aux: rust_htslib::bam::record::Aux) -> String {
     match aux {
@@ -87,9 +186,56 @@ pub(crate) fn ellipsis(s: &str, max_len: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::utils::{ellipsis, get_fasta_contigs, get_fasta_length, get_ref_and_bam_from_cwd};
-    use std::path::PathBuf;
+    use crate::utils::{
+        bam_index_present, build_bam_index, build_fasta_index, build_vcf_index, ellipsis,
+        fasta_index_present, get_fasta_contigs, get_fasta_length, get_ref_and_bam_from_cwd,
+        vcf_index_present,
+    };
+    use std::path::{Path, PathBuf};
     use std::str::FromStr;
+    use tempfile::TempDir;
+
+    fn copy_to_temp(fixture: &str) -> (TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(Path::new(fixture).file_name().unwrap());
+        std::fs::copy(fixture, &path).unwrap();
+        (dir, path)
+    }
+
+    #[test]
+    fn test_build_bam_index() {
+        let (_dir, bam) = copy_to_temp("tests/sample_1/reads.bam");
+        assert!(!bam_index_present(&bam));
+        build_bam_index(&bam).unwrap();
+        assert!(bam_index_present(&bam));
+        assert!(rust_htslib::bam::IndexedReader::from_path(&bam).is_ok());
+    }
+
+    #[test]
+    fn test_build_fasta_index() {
+        let (_dir, fasta) = copy_to_temp("tests/sample_1/reference.fa");
+        assert!(!fasta_index_present(&fasta));
+        build_fasta_index(&fasta).unwrap();
+        assert!(fasta_index_present(&fasta));
+    }
+
+    #[test]
+    fn test_build_vcf_index_for_bgzipped_vcf() {
+        let (_dir, vcf) = copy_to_temp("tests/sample_3/1257A.vcf.gz");
+        assert!(!vcf_index_present(&vcf));
+        let indexed = build_vcf_index(&vcf).unwrap();
+        assert_eq!(indexed, vcf);
+        assert!(vcf_index_present(&vcf));
+    }
+
+    #[test]
+    fn test_build_vcf_index_bgzips_plain_vcf() {
+        let (_dir, vcf) = copy_to_temp("tests/sample_3/1257A.vcf");
+        let indexed = build_vcf_index(&vcf).unwrap();
+        assert_eq!(indexed, vcf.with_extension("vcf.gz"));
+        assert!(vcf_index_present(&indexed));
+        assert!(rust_htslib::bcf::IndexedReader::from_path(&indexed).is_ok());
+    }
 
     #[test]
     fn test_get_fasta_length() {

--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -1,10 +1,13 @@
 use crate::cli::{Alignoth, Around, Clamp, FromAround, Interval, Region};
-use crate::utils::{get_fasta_contigs, get_fasta_length};
-use anyhow::Result;
-use inquire::{Select, Text};
+use crate::utils::{
+    bam_index_present, build_bam_index, build_fasta_index, build_vcf_index, fasta_index_present,
+    get_fasta_contigs, get_fasta_length, vcf_index_present,
+};
+use anyhow::{bail, Result};
+use inquire::{Confirm, Select, Text};
 use std::fmt::Display;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 pub(crate) async fn wizard_mode() -> Result<Alignoth> {
@@ -43,23 +46,31 @@ pub(crate) async fn wizard_mode() -> Result<Alignoth> {
         .collect();
 
     let bam_path = if bam_files.is_empty() {
-        Text::new("Path to BAM file:").prompt()?
+        PathBuf::from(Text::new("Path to BAM file:").prompt()?)
     } else {
         let choices: Vec<_> = bam_files.iter().map(|p| p.display().to_string()).collect();
-        Select::new("Select BAM file:", choices).prompt()?
+        PathBuf::from(Select::new("Select BAM file:", choices).prompt()?)
     };
+    ensure_required_index(&bam_path, bam_index_present(&bam_path), || {
+        build_bam_index(&bam_path)
+    })?;
 
     let reference_path = if fasta_files.is_empty() {
-        Text::new("Path to reference FASTA file:").prompt()?
+        PathBuf::from(Text::new("Path to reference FASTA file:").prompt()?)
     } else {
         let choices: Vec<_> = fasta_files
             .iter()
             .map(|p| p.display().to_string())
             .collect();
-        Select::new("Select reference FASTA file:", choices).prompt()?
+        PathBuf::from(Select::new("Select reference FASTA file:", choices).prompt()?)
     };
+    ensure_required_index(
+        &reference_path,
+        fasta_index_present(&reference_path),
+        || build_fasta_index(&reference_path),
+    )?;
 
-    let contigs = get_fasta_contigs(&PathBuf::from(reference_path.clone()))?;
+    let contigs = get_fasta_contigs(&reference_path)?;
     let target = Select::new("Select target contig/chromosome:", contigs).prompt()?;
 
     let mut region = match Select::new(
@@ -87,13 +98,16 @@ pub(crate) async fn wizard_mode() -> Result<Alignoth> {
         _ => unreachable!(),
     };
 
-    let target_length = get_fasta_length(&PathBuf::from(reference_path.clone()), &target)? as i64;
+    let target_length = get_fasta_length(&reference_path, &target)? as i64;
     region = region.clamp(0, target_length - 1);
-    let vcf_input = select_optional_file(
+    let vcf_input = match select_optional_file(
         "Do you want to provide a VCF file to highlight variant positions?",
         "path/to/file.vcf",
         &vcf_files,
-    )?;
+    )? {
+        Some(vcf) => ensure_optional_vcf_index(vcf)?,
+        None => None,
+    };
     let bed_input = select_optional_file(
         "Do you want to provide a BED file to highlight certain regions?",
         "path/to/file.bed",
@@ -123,8 +137,8 @@ pub(crate) async fn wizard_mode() -> Result<Alignoth> {
         == "Interactive HTML";
 
     Ok(Alignoth {
-        bam_path: vec![bam_path.into()],
-        reference: Some(reference_path.into()),
+        bam_path: vec![bam_path],
+        reference: Some(reference_path),
         region: Some(region),
         aux_tag: aux_tags,
         max_read_depth,
@@ -146,6 +160,44 @@ pub(crate) async fn wizard_mode() -> Result<Alignoth> {
         no_embed_js: false,
         mismatch_display_min_percent: 1.0,
     })
+}
+
+/// Asks whether to create a missing index for `path`, defaulting to yes.
+fn confirm_create_index(path: &Path) -> Result<bool> {
+    Ok(Confirm::new(&format!(
+        "No index found for {}. Create it now?",
+        path.display()
+    ))
+    .with_default(true)
+    .prompt()?)
+}
+
+/// Ensures a required index exists, offering to build it. Aborts the wizard if the user declines.
+fn ensure_required_index(
+    path: &Path,
+    present: bool,
+    build: impl FnOnce() -> Result<()>,
+) -> Result<()> {
+    if present {
+        Ok(())
+    } else if confirm_create_index(path)? {
+        build()
+    } else {
+        bail!("An index is required for {}.", path.display());
+    }
+}
+
+/// Ensures an index for an optional VCF, offering to build it (bgzipping a plain `.vcf` if needed).
+/// Returns the effective path, or `None` if the user declines and the VCF is skipped.
+fn ensure_optional_vcf_index(path: PathBuf) -> Result<Option<PathBuf>> {
+    if vcf_index_present(&path) {
+        Ok(Some(path))
+    } else if confirm_create_index(&path)? {
+        Ok(Some(build_vcf_index(&path)?))
+    } else {
+        println!("Skipping VCF highlighting for {}.", path.display());
+        Ok(None)
+    }
 }
 
 /// Asks the user for an optional file, letting them pick from `candidates` found in the current

--- a/tests/sample_3/1257A.vcf
+++ b/tests/sample_3/1257A.vcf
@@ -1,0 +1,7 @@
+##fileformat=VCFv4.3
+##FILTER=<ID=PASS,Description="All filters passed">
+##contig=<ID=1,length=1000>
+##bcftools_viewVersion=1.19+htslib-1.22.1
+##bcftools_viewCommand=view -O v -o tests/sample_3/1257A.vcf tests/sample_3/1257A.vcf.gz; Date=Thu Jul  9 12:57:48 2026
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+1	257	.	A	G	.	.	.


### PR DESCRIPTION
Creates missing bam/fasta/vcf indexes instead of just dying. Wizard asks first, cli just does it. Also a plain vcf gets bgzipped.