### PR TITLE
fix: Support bgzipped FASTA references

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -185,22 +185,16 @@ impl Preprocess for Alignoth {
         }
         if let Some(around) = &self.around {
             self.region = Some(Region::from_around(around));
-            let target = self.region.as_ref().unwrap().target.clone();
-            let target_length =
-                get_fasta_length(self.reference.as_ref().unwrap(), &target).unwrap() as i64;
-            let region = self.region.as_mut().unwrap();
-            self.region = Some(region.clamp(0, target_length - 1));
         } else if let Some(vcf_record_index) = &self.around_vcf_record {
             self.region = Some(Region::from_vcf_record(
                 *vcf_record_index,
                 self.vcf.as_ref().unwrap(),
             )?);
-            let target = self.region.as_ref().unwrap().target.clone();
-            let target_length =
-                get_fasta_length(self.reference.as_ref().unwrap(), &target).unwrap() as i64;
-            let region = self.region.as_mut().unwrap();
-            self.region = Some(region.clamp(0, target_length - 1));
         }
+        let region = self.region.as_ref().unwrap();
+        let target_length =
+            get_fasta_length(self.reference.as_ref().unwrap(), &region.target)? as i64;
+        self.region = Some(region.clamp(0, target_length));
         Ok(())
     }
 }
@@ -501,7 +495,7 @@ impl Interval {
 
 #[cfg(test)]
 mod tests {
-    use crate::cli::{Alignoth, Around, DataFormat, FromAround, Interval, Region};
+    use crate::cli::{Alignoth, Around, DataFormat, FromAround, Interval, Preprocess, Region};
     use std::path::PathBuf;
     use std::str::FromStr;
 
@@ -535,6 +529,33 @@ mod tests {
             mismatch_display_min_percent: 1.0,
             clamp_reads: false,
         }
+    }
+
+    fn preprocessed_region(region: Option<Region>, around: Option<Around>) -> Region {
+        let mut opt = Alignoth {
+            bam_path: vec![PathBuf::from("tests/sample_1/reads.bam")],
+            reference: Some(PathBuf::from("tests/sample_1/reference.fa")),
+            region,
+            around,
+            ..base_alignoth()
+        };
+        opt.preprocess().unwrap();
+        opt.region.unwrap()
+    }
+
+    #[test]
+    fn test_preprocess_clamps_region_to_target_bounds() {
+        // chr1 is 123bp; a region reaching past the end is clamped, not rejected.
+        let clamped = preprocessed_region(Some(Region::from_str("chr1:110-140").unwrap()), None);
+        assert_eq!((clamped.start, clamped.end), (109, 123));
+
+        // An exact whole-contig region keeps its final base.
+        let whole = preprocessed_region(Some(Region::from_str("chr1:1-123").unwrap()), None);
+        assert_eq!((whole.start, whole.end), (0, 123));
+
+        // --around covers the whole contig too, rather than dropping the last base.
+        let around = preprocessed_region(None, Some(Around::from_str("chr1:100").unwrap()));
+        assert_eq!((around.start, around.end), (0, 123));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -545,15 +545,12 @@ mod tests {
 
     #[test]
     fn test_preprocess_clamps_region_to_target_bounds() {
-        // chr1 is 123bp; a region reaching past the end is clamped, not rejected.
         let clamped = preprocessed_region(Some(Region::from_str("chr1:110-140").unwrap()), None);
         assert_eq!((clamped.start, clamped.end), (109, 123));
 
-        // An exact whole-contig region keeps its final base.
         let whole = preprocessed_region(Some(Region::from_str("chr1:1-123").unwrap()), None);
         assert_eq!((whole.start, whole.end), (0, 123));
 
-        // --around covers the whole contig too, rather than dropping the last base.
         let around = preprocessed_region(None, Some(Around::from_str("chr1:100").unwrap()));
         assert_eq!((around.start, around.end), (0, 123));
     }

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -2,7 +2,6 @@ use crate::cli;
 use crate::cli::Region;
 use crate::utils::{aux_to_string, get_fasta_length};
 use anyhow::{Context, Result};
-use bio::io::fasta;
 use itertools::Itertools;
 use log::warn;
 use rand::prelude::IteratorRandom;
@@ -13,6 +12,7 @@ use rust_htslib::bam::ext::BamRecordExtensions;
 use rust_htslib::bam::record::{Cigar, CigarString, CigarStringView};
 use rust_htslib::bam::FetchDefinition::Region as FetchRegion;
 use rust_htslib::bam::Read as HtslibRead;
+use rust_htslib::faidx;
 use serde::{Serialize, Serializer};
 use std::cmp::{max, min};
 use std::collections::{HashMap, HashSet};
@@ -75,16 +75,16 @@ pub(crate) fn create_plot_data<P: AsRef<Path> + std::fmt::Debug>(
 
 /// Reads the given region from the given fasta file and returns it as a vec of the bases as chars
 fn read_fasta<P: AsRef<Path> + std::fmt::Debug>(path: P, region: &Region) -> Result<Vec<char>> {
-    let mut reader = fasta::IndexedReader::from_file(&path).unwrap();
-    let index =
-        fasta::Index::with_fasta_file(&path).context("error reading index file of input FASTA")?;
-    let _sequences = index.sequences();
-
-    let mut seq: Vec<u8> = Vec::new();
-
-    reader.fetch(&region.target, region.start as u64, region.end as u64)?;
-    reader.read(&mut seq)?;
-
+    if region.end <= region.start {
+        return Ok(Vec::new());
+    }
+    let reader =
+        faidx::Reader::from_path(&path).context("error reading index file of input FASTA")?;
+    let seq = reader.fetch_seq(
+        &region.target,
+        region.start as usize,
+        (region.end - 1) as usize,
+    )?;
     Ok(seq.iter().map(|u| char::from(*u)).collect_vec())
 }
 
@@ -1095,6 +1095,34 @@ mod tests {
         .unwrap();
         let expected_reference = "TTGCCGGGGTGGGGAGAGAG".chars().collect_vec();
         assert_eq!(reference, expected_reference);
+    }
+
+    #[test]
+    fn test_create_plot_data_with_bgzipped_reference() {
+        let region = Region {
+            target: "chr1".to_string(),
+            start: 0,
+            end: 20,
+        };
+        let plot = |reference: &str| {
+            create_plot_data(
+                "tests/sample_1/reads.bam",
+                reference,
+                &region,
+                100,
+                None,
+                0.0,
+                false,
+                "sample_1".to_string(),
+            )
+            .unwrap()
+        };
+        let (_dir, gz) = crate::utils::tests::bgzipped_reference();
+        let (gz_reads, gz_reference, _, gz_coverage, _) = plot(gz.to_str().unwrap());
+        let (reads, reference, _, coverage, _) = plot("tests/sample_1/reference.fa");
+        assert_eq!(gz_reference, reference);
+        assert_eq!(gz_reads, reads);
+        assert_eq!(gz_coverage, coverage);
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,29 +1,50 @@
-use anyhow::{anyhow, Context, Result};
-use bio::io::fasta;
+use anyhow::{anyhow, bail, Context, Result};
 use itertools::Itertools;
 use rust_htslib::bcf::{Format, Header, Read as BcfRead, Reader, Writer};
-use rust_htslib::{bam, bcf};
+use rust_htslib::{bam, bcf, faidx};
 use std::fs;
 use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy)]
+pub(crate) enum FileKind {
+    Alignment,
+    Fasta,
+    Vcf,
+    Bed,
+}
+
+impl FileKind {
+    pub(crate) fn suffixes(self) -> &'static [&'static str] {
+        match self {
+            FileKind::Alignment => &[".bam", ".sam", ".cram"],
+            FileKind::Fasta => &[".fa", ".fasta", ".fa.gz", ".fasta.gz"],
+            FileKind::Vcf => &[".vcf.gz", ".bcf", ".vcf"],
+            FileKind::Bed => &[".bed"],
+        }
+    }
+
+    pub(crate) fn matches(self, path: &Path) -> bool {
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| self.suffixes().iter().any(|suffix| name.ends_with(suffix)))
+    }
+}
 
 // Check if the cwd contains only one fasta (.fa, .fasta, .fasta.gz, .fa.gz) file and at least one bam (.bam, .bam.gz) file. Returns the fasta path and a vector of all bam paths.
 pub(crate) fn get_ref_and_bam_from_cwd() -> Result<Option<(PathBuf, Vec<PathBuf>)>> {
     let mut fasta_path: Option<PathBuf> = None;
     let mut bam_paths: Vec<PathBuf> = Vec::new();
     for entry in fs::read_dir(".")? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_file() && path.extension().is_some() {
-            let ext = path.extension().unwrap().to_str().unwrap();
-            if ext == "fa" || ext == "fasta" || ext == "fa.gz" || ext == "fasta.gz" {
-                if fasta_path.is_some() {
-                    // There is already a fasta file in the cwd
-                    return Ok(None);
-                }
-                fasta_path = Some(path);
-            } else if ext == "bam" || ext == "bam.gz" {
-                bam_paths.push(path);
+        let path = entry?.path();
+        if !path.is_file() {
+            continue;
+        }
+        if FileKind::Fasta.matches(&path) {
+            if fasta_path.replace(path).is_some() {
+                return Ok(None);
             }
+        } else if FileKind::Alignment.matches(&path) {
+            bam_paths.push(path);
         }
     }
     if let Some(fasta) = fasta_path {
@@ -36,22 +57,19 @@ pub(crate) fn get_ref_and_bam_from_cwd() -> Result<Option<(PathBuf, Vec<PathBuf>
 
 // Get length of fasta file and given target
 pub(crate) fn get_fasta_length(fasta_path: &PathBuf, target: &str) -> Result<usize> {
-    let mut fasta_reader = fasta::IndexedReader::from_file(fasta_path)?;
-    let mut seq: Vec<u8> = Vec::new();
-    fasta_reader.fetch_all(target)?;
-    fasta_reader.read(&mut seq)?;
-    Ok(seq.len())
+    let reader = faidx::Reader::from_path(fasta_path)?;
+    if !reader.seq_names()?.iter().any(|name| name == target) {
+        bail!(
+            "FASTA file {} does not contain target {target}",
+            fasta_path.display()
+        );
+    }
+    Ok(reader.fetch_seq_len(target) as usize)
 }
 
 // Get all contigs/chromosomes from fasta file
 pub(crate) fn get_fasta_contigs(fasta_path: &PathBuf) -> Result<Vec<String>> {
-    let fasta_reader = fasta::Reader::from_file(fasta_path)?;
-    let mut contigs = Vec::new();
-    for record in fasta_reader.records() {
-        let record = record?;
-        contigs.push(record.id().to_string());
-    }
-    Ok(contigs)
+    Ok(faidx::Reader::from_path(fasta_path)?.seq_names()?)
 }
 
 /// Returns `path` with `.extension` appended, e.g. `reads.bam` + `bai` -> `reads.bam.bai`.
@@ -85,9 +103,16 @@ pub(crate) fn build_bam_index(path: &Path) -> Result<()> {
     })
 }
 
-/// Returns whether a `.fai` index exists next to the given FASTA file.
+/// Returns whether a `.fai` index exists next to the given FASTA file. A bgzipped FASTA
+/// additionally requires a `.gzi` index for random access.
 pub(crate) fn fasta_index_present(path: &Path) -> bool {
     appended_extension(path, "fai").exists()
+        && (!is_bgzipped(path) || appended_extension(path, "gzi").exists())
+}
+
+/// Returns whether the given path looks bgzipped, i.e. ends in `.gz`.
+fn is_bgzipped(path: &Path) -> bool {
+    path.extension().is_some_and(|extension| extension == "gz")
 }
 
 /// Builds a `.fai` index for the given FASTA file.
@@ -207,15 +232,56 @@ pub(crate) fn ellipsis(s: &str, max_len: usize) -> String {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use crate::utils::{
         bam_index_present, build_bam_index, build_fasta_index, build_vcf_index, ellipsis,
         fasta_index_present, get_fasta_contigs, get_fasta_length, get_ref_and_bam_from_cwd,
         vcf_index_present,
     };
+    use std::io::Write;
     use std::path::{Path, PathBuf};
     use std::str::FromStr;
     use tempfile::TempDir;
+
+    pub(crate) fn bgzipped_reference() -> (TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("reference.fa.gz");
+        let plain = std::fs::read("tests/sample_1/reference.fa").unwrap();
+        let mut writer = rust_htslib::bgzf::Writer::from_path(&path).unwrap();
+        writer.write_all(&plain).unwrap();
+        drop(writer);
+        build_fasta_index(&path).unwrap();
+        (dir, path)
+    }
+
+    #[test]
+    fn test_bgzipped_fasta_contigs_and_length_match_plain() {
+        let plain = PathBuf::from("tests/sample_1/reference.fa");
+        let (_dir, gz) = bgzipped_reference();
+        assert_eq!(get_fasta_contigs(&gz).unwrap(), vec!["chr1".to_string()]);
+        assert_eq!(
+            get_fasta_contigs(&gz).unwrap(),
+            get_fasta_contigs(&plain).unwrap()
+        );
+        assert_eq!(
+            get_fasta_length(&gz, "chr1").unwrap(),
+            get_fasta_length(&plain, "chr1").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_bgzipped_fasta_index_requires_gzi() {
+        let (dir, gz) = bgzipped_reference();
+        assert!(fasta_index_present(&gz));
+        std::fs::remove_file(dir.path().join("reference.fa.gz.gzi")).unwrap();
+        assert!(!fasta_index_present(&gz));
+    }
+
+    #[test]
+    fn test_get_fasta_length_rejects_unknown_target() {
+        let plain = PathBuf::from("tests/sample_1/reference.fa");
+        assert!(get_fasta_length(&plain, "nonexistent").is_err());
+    }
 
     fn copy_to_temp(fixture: &str) -> (TempDir, PathBuf) {
         let dir = tempfile::tempdir().unwrap();

--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -1,7 +1,7 @@
-use crate::cli::{Alignoth, Around, Clamp, FromAround, Interval, Region};
+use crate::cli::{Alignoth, Around, FromAround, Interval, Region};
 use crate::utils::{
     bam_index_present, build_bam_index, build_fasta_index, build_vcf_index, fasta_index_present,
-    get_fasta_contigs, get_fasta_length, vcf_index_present,
+    get_fasta_contigs, vcf_index_present, FileKind,
 };
 use anyhow::{bail, Result};
 use inquire::autocompletion::Replacement;
@@ -45,7 +45,7 @@ pub(crate) async fn wizard_mode() -> Result<Alignoth> {
     let contigs = get_fasta_contigs(&reference_path)?;
     let target = Select::new("Select target contig/chromosome:", contigs).prompt()?;
 
-    let mut region = match Select::new(
+    let region = match Select::new(
         "Do you want to visualize around a certain position or a specific region?",
         vec!["Around a position", "Region"],
     )
@@ -75,8 +75,6 @@ pub(crate) async fn wizard_mode() -> Result<Alignoth> {
         .prompt()?
         .parse()?;
 
-    let target_length = get_fasta_length(&reference_path, &target)? as i64;
-    region = region.clamp(0, target_length - 1);
     let vcf_input = match select_optional_file(
         "Do you want to provide a VCF file to highlight variant positions?",
         "path/to/file.vcf",
@@ -177,31 +175,6 @@ fn ensure_optional_vcf_index(path: PathBuf) -> Result<Option<PathBuf>> {
     } else {
         println!("Skipping VCF highlighting for {}.", path.display());
         Ok(None)
-    }
-}
-
-#[derive(Clone, Copy)]
-enum FileKind {
-    Alignment,
-    Fasta,
-    Vcf,
-    Bed,
-}
-
-impl FileKind {
-    fn suffixes(self) -> &'static [&'static str] {
-        match self {
-            FileKind::Alignment => &[".bam", ".sam", ".cram"],
-            FileKind::Fasta => &[".fa", ".fasta"],
-            FileKind::Vcf => &[".vcf.gz", ".bcf", ".vcf"],
-            FileKind::Bed => &[".bed"],
-        }
-    }
-
-    fn matches(self, path: &Path) -> bool {
-        path.file_name()
-            .and_then(|name| name.to_str())
-            .is_some_and(|name| self.suffixes().iter().any(|suffix| name.ends_with(suffix)))
     }
 }
 


### PR DESCRIPTION
Migrates from `bio::io::fasta` to `rust_htslib::faidx` to support bgzipped FASTA references.