### PR TITLE
feat: Fill available width for HTML plots by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following options are available when using alignoth:
 | bed                   | -b    | Path to a BED file. Regions from the BED file will be highlighted in the resulting plot similar to the highlight option.                                          |         |
 | plot-all              | -p    | Plot all reads in the given region. We advise to only use this command for small bam files with a single target.                                                  | false   |
 | max-read-depth        | -d    | Set the maximum rows of reads that will be shown in the alignment plots                                                                                           | 500     |
-| max-width             | -w    | Set the maximum width of the resulting alignment plot                                                                                                             | 1024    |
+| max-width             | -w    | Set the maximum width of the resulting alignment plot. If unset, HTML plots fill the available window width while other outputs default to 1024.                  | 1024    |
 | output                | -o    | If present, data and vega-lite specs of the generated plot will be split and written to the given directory                                                       |         |
 | data-format           | -f    | Sets the output format for the read, reference and highlight data                                                                                                 | json    |
 | aux_tag               | -x    | Displays the given content of the aux tag in the tooltip of the plot. Multiple usage for more than one tag is possible.                                           |         |

--- a/resources/plot.html.tera
+++ b/resources/plot.html.tera
@@ -193,6 +193,19 @@
 <script>
     const compressed_spec = {{ spec | safe }};
     const spec = JSON.parse(LZString.decompressFromUTF16(compressed_spec));
+    {% if autofit %}
+    {
+        const MAX_PX_PER_BASE = 20;
+        const AXIS_LEGEND_WIDTH = 200;
+        const MIN_WIDTH = 300;
+        const domain = spec.vconcat[1].encoding.x.scale.domain;
+        const bases = domain[1] - domain[0];
+        const available = document.getElementById("vis").clientWidth - AXIS_LEGEND_WIDTH;
+        const width = Math.min(bases * MAX_PX_PER_BASE, Math.max(available, MIN_WIDTH));
+        spec.vconcat[0].width = width;
+        spec.vconcat[1].width = width;
+    }
+    {% endif %}
     let fullData = [];
     vegaEmbed("#vis", spec, {mode: "vega-lite"}).then(({ view }) => {
         fullReads = view.data('reads');

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,9 +64,9 @@ pub struct Alignoth {
     #[structopt(long, short = "f", default_value)]
     pub(crate) data_format: DataFormat,
 
-    /// Sets the maximum width of the resulting plot.
-    #[structopt(long, short = "w", default_value = "1024")]
-    pub(crate) max_width: i64,
+    /// Sets the maximum width of the resulting plot. Defaults to 1024, or to the available width when rendering to HTML.
+    #[structopt(long, short = "w")]
+    pub(crate) max_width: Option<i64>,
 
     /// If present vega-lite specs will be written to the given file path
     #[structopt(long, parse(from_os_str), conflicts_with("output"))]
@@ -516,7 +516,7 @@ mod tests {
             bed: None,
             max_read_depth: 500,
             data_format: DataFormat::Json,
-            max_width: 1024,
+            max_width: Some(1024),
             spec_output: None,
             ref_data_output: None,
             read_data_output: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,11 @@ async fn main() -> Result<()> {
     let region = opt.region.as_ref().unwrap();
 
     let mut plot_specs: Value = serde_json::from_str(include_str!("../resources/plot.vl.json"))?;
-    let width = json!(min(opt.max_width, 5 * region.length()));
+    let width = match opt.max_width {
+        Some(max_width) => Some(min(max_width, 5 * region.length())),
+        None if opt.html => None,
+        None => Some(min(1024, 5 * region.length())),
+    };
     let domain = json!(vec![region.start as f32 - 0.5, region.end as f32 - 0.5]);
 
     let template_coverage = plot_specs["vconcat"][0].clone();
@@ -136,7 +140,9 @@ async fn main() -> Result<()> {
         };
 
         let mut cov = template_coverage.clone();
-        cov["width"] = width.clone();
+        if let Some(width) = width {
+            cov["width"] = json!(width);
+        }
         if i == 0 {
             cov["title"] = json!({
                 "text": &region.target,
@@ -153,7 +159,9 @@ async fn main() -> Result<()> {
         cov["encoding"]["y"]["axis"]["title"] = json!(format!("{} cov", bam_name));
 
         let mut rds = template_reads.clone();
-        rds["width"] = width.clone();
+        if let Some(width) = width {
+            rds["width"] = json!(width);
+        }
         rds["encoding"]["x"]["scale"]["domain"] = domain.clone();
         rds["encoding"]["y"]["axis"]["title"] = json!(subsampling_warning);
 
@@ -281,6 +289,7 @@ async fn main() -> Result<()> {
             templates.add_raw_template("plot", include_str!("../resources/plot.html.tera"))?;
             let mut context = Context::new();
             context.insert("num_bams", &opt.bam_path.len());
+            context.insert("autofit", &width.is_none());
             context.insert(
                 "spec",
                 &json!(compress_to_utf16(&plot_specs.to_string())).to_string(),

--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -119,7 +119,7 @@ pub(crate) async fn wizard_mode() -> Result<Alignoth> {
         region: Some(region),
         aux_tag: aux_tags,
         max_read_depth,
-        max_width: 1024,
+        max_width: None,
         output: None,
         data_format: Default::default(),
         html: html_output,


### PR DESCRIPTION
This PR lets alignoth use the full available width in interactive plots created via `--html`.