### PR TITLE
fix: Drop redundant y-axis title from coverage track

### DIFF
--- a/resources/plot.vl.json
+++ b/resources/plot.vl.json
@@ -78,7 +78,7 @@
           "type": "quantitative",
           "stack": true,
           "axis": {
-            "title": "Coverage"
+            "title": null
           }
         },
         "color": {

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,6 @@ async fn main() -> Result<()> {
                 json!({ "filter": format!("datum.sample == '{}'", bam_name) }),
             );
         }
-        cov["encoding"]["y"]["axis"]["title"] = json!(format!("{} cov", bam_name));
 
         let mut rds = template_reads.clone();
         if let Some(width) = width {


### PR DESCRIPTION
Tiny PR dropping the redundant y-axis title from coverage track.